### PR TITLE
Fix typos, indentation, and add missing docstrings (QKmeans + Grover)

### DIFF
--- a/pyqpanda-algorithm/pyqpanda_alg/Grover/Grover_core.py
+++ b/pyqpanda-algorithm/pyqpanda_alg/Grover/Grover_core.py
@@ -25,7 +25,7 @@ class Grover:
             Operator/Circuit of marking the good states by phase-flip. Default doing a pauli-Z
             gate at the last qubit.
         zero_flip : callable ``f(qubits)``\n
-            Operator/Circuit of reflects 0s by phase-flip. Default doing a zero-controled pauli-Z
+            Operator/Circuit of reflects 0s by phase-flip. Default doing a zero-controlled pauli-Z
             gate on qubits.
         mark_data : ``str``, ``list[str]``\n
             Marked target state. Default None.
@@ -246,7 +246,7 @@ def amp_operator(q_input=None, q_flip=None, q_zero=None, in_operator=None, flip_
             Operator/Circuit of marking the good states by phase-flip. Default doing a pauli-Z
             gate at the last qubit.
         zero_flip : callable ``f(qubits)``\n
-            Operator/Circuit of reflects 0s by phase-flip. Default doing a zero-controled pauli-Z
+            Operator/Circuit of reflects 0s by phase-flip. Default doing a zero-controlled pauli-Z
             gate on qubits.
 
     Returns

--- a/pyqpanda-algorithm/pyqpanda_alg/QKmeans/QuantumKmeans.py
+++ b/pyqpanda-algorithm/pyqpanda_alg/QKmeans/QuantumKmeans.py
@@ -19,6 +19,29 @@ from pyqpanda3.core import CPUQVM, QCircuit, QProg, SWAP, U3, H, measure, draw_q
 
 
 def _QuantumKmeansCircuit(theta0, phi0, theta, phi):
+    """
+    Build and run a swap-test circuit to estimate the distance between two qubit states.
+
+    Uses the swap test: a Hadamard on an ancilla qubit, a controlled-SWAP between the two
+    data qubits, and a final Hadamard, then measures the ancilla. The probability of
+    measuring ``|1>`` on the ancilla is related to the inner product of the two states.
+
+    Parameters
+        theta0 : ``float``\n
+            Polar angle (theta) for the U3 gate encoding the first data point's x-coordinate.
+        phi0 : ``float``\n
+            Azimuthal angle (phi) for the U3 gate encoding the first data point's y-coordinate.
+        theta : ``float``\n
+            Polar angle (theta) for the U3 gate encoding the second data point's x-coordinate.
+        phi : ``float``\n
+            Azimuthal angle (phi) for the U3 gate encoding the second data point's y-coordinate.
+
+    Returns
+        result : ``dict``\n
+            Measurement probability dictionary for the ancilla qubit. Key ``'1'`` gives the
+            probability of measuring ``|1>``, which is proportional to the distance between
+            the two encoded states.
+    """
     machine = CPUQVM()
     prog = QProg(3)
     qlist = prog.qubits()
@@ -39,12 +62,33 @@ def _QuantumKmeansCircuit(theta0, phi0, theta, phi):
 
 
 def _point_centroid_distances(point, centroids, k):
+    """
+    Compute quantum-estimated distances from a data point to each of k centroids.
+
+    Encodes the x- and y-coordinates of the point and each centroid as qubit rotation
+    angles via a linear mapping to [0, pi], then calls ``_QuantumKmeansCircuit`` for
+    each centroid to obtain a swap-test probability proportional to the distance.
+
+    Parameters
+        point : ``array-like`` of length 2\n
+            A 2D data point ``[x, y]`` with values in [-1, 1].
+        centroids : ``list`` of array-like\n
+            List of k centroid coordinates, each of the form ``[x, y]``.
+        k : ``int``\n
+            Number of centroids (clusters).
+
+    Returns
+        results_list : ``list`` of ``float``\n
+            List of length k. Each element is the swap-test probability of measuring
+            ``|1>`` for the corresponding centroid — higher values indicate greater
+            distance from the data point to that centroid.
+    """
     xval = [point[0]]
     for i in range(k):
-      xval.append(centroids[i][0])
+        xval.append(centroids[i][0])
     yval = [point[1]]
     for i in range(k):
-      yval.append(centroids[i][1])
+        yval.append(centroids[i][1])
 
     theta_t = [((x + 1) * pi / 2) for x in xval]
     theta_c = [((x + 1) * pi / 2) for x in yval]

--- a/pyqpanda-algorithm/pyqpanda_alg/__init__.py
+++ b/pyqpanda-algorithm/pyqpanda_alg/__init__.py
@@ -32,7 +32,6 @@ warnings.filterwarnings("ignore", category=SyntaxWarning)
 from . import QAOA
 # from . import VQE
 # from . import HHL
-# from . import QAOA
 from . import QARM
 from . import QKmeans
 # from . import QLuoShu


### PR DESCRIPTION
Fix typos, indentation, and missing docstrings in QKmeans and Grover modules

## Changes

**Grover/Grover_core.py**
- Fix typo: `zero-controled` → `zero-controlled` (appears in 2 docstring locations)

**QKmeans/QuantumKmeans.py**
- Fix inconsistent 2-space indentation in `_point_centroid_distances` loop bodies → 4-space (PEP 8)
- Add missing docstring to `_QuantumKmeansCircuit`: explains the swap-test circuit, all parameters, and return value
- Add missing docstring to `_point_centroid_distances`: explains encoding strategy, parameters, and return value

**pyqpanda_alg/__init__.py**
- Remove duplicate commented-out `# from . import QAOA` (already imported on the preceding line)

Relates to Issue #1 (内容纠错与注释补充)
