### PR TITLE
【创新应用】SU(2) detector-response toy simulation demo

### DIFF
--- a/SU2DetectorResponseToy/.gitignore
+++ b/SU2DetectorResponseToy/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+.pytest_cache/
+.venv/
+*.pyc
+*.pyo
+outputs*/
+Tutorials/SU2DetectorResponseToy/outputs*/

--- a/SU2DetectorResponseToy/README.md
+++ b/SU2DetectorResponseToy/README.md
@@ -1,0 +1,210 @@
+# SU(2) Detector Response Toy Simulation
+
+## 项目简介
+
+本项目是一个面向量子算法创新应用的 SU(2) 对称量子多体模拟示例。项目使用小规模 color-chain toy Hamiltonian，展示 SU(2) singlet 态制备、singlet/triplet sector 能谱分析、局域 color-singlet quench 以及左右探测点的 connected color correlation。
+
+该示例默认使用 4 到 8 个 qubit，可在本地完成精确对角化扫描、图表生成和基础线路导出；同时提供 pyQPanda CPUQVM 示例，便于学习和迁移到 pyQPanda 生态。
+
+本项目定位为一个自包含教程型贡献：NumPy 精确对角化部分提供可复现实验参考量，pyQPanda CPUQVM 脚本展示对应的 singlet 态制备与局域 probe 线路构造方式。
+
+## 任务类型
+
+```text
+【创新应用】SU(2) detector-response toy simulation demo
+```
+
+## 主要功能
+
+- 构造 SU(2)-scalar color interaction：$S_i \cdot S_j$。
+- 扫描 dimerization 参数下的低能谱结构。
+- 计算 total spin sector，用于区分 singlet 与 triplet 能级。
+- 对中心 bond 施加 color-singlet local quench。
+- 计算 quench energy injection 与 low-level spectral weights。
+- 计算左右 detector sites 的 connected color correlation。
+- 导出 singlet-pair state preparation 与 color-quench probe 的 OpenQASM 原型。
+- 提供 pyQPanda CPUQVM 示例脚本。
+
+## 目录结构
+
+```text
+SU2DetectorResponseToy/
+├── README.md
+├── SUBMISSION_CHECKLIST.md
+├── contest_pitch.txt
+├── requirements.txt
+├── run_demo.py
+├── make_plots.py
+├── pyqpanda_demo.py
+├── src/eec_toy/
+├── tests/test_eec_toy.py
+└── Tutorials/SU2DetectorResponseToy/
+    ├── README.md
+    ├── DERIVATION.md
+    ├── CONTRIBUTION_NOTE.md
+    ├── PR_DESCRIPTION.md
+    ├── run_tutorial.py
+    ├── make_tutorial_plots.py
+    └── pyqpanda_cpuqvm_example.py
+```
+
+## 安装依赖
+
+```bash
+pip install -r requirements.txt
+```
+
+依赖包括：
+
+```text
+numpy
+matplotlib
+pyqpanda
+```
+
+其中 `pyqpanda` 用于 CPUQVM 示例；如果只运行数值扫描和画图，`numpy` 与 `matplotlib` 即可。
+
+## 赛事指定工具使用说明
+
+本项目使用 pyQPanda CPUQVM 构造并运行 singlet-pair preparation 与 central color-quench probe 线路。NumPy 精确对角化部分用于生成参考观测量，帮助解释和验证量子线路示例的物理含义；pyQPanda CPUQVM 部分用于展示可执行的量子编程入口；OpenQASM 导出用于连接线路原型与后续模拟器或硬件迁移。
+
+因此，本项目的设计关系为：
+
+```text
+NumPy exact diagonalization -> reference observables
+OpenQASM export             -> portable circuit prototype
+pyQPanda CPUQVM             -> executable circuit realization
+```
+
+## 运行示例
+
+### 1. 运行 SU(2) 扫描
+
+```bash
+python run_demo.py --num-qubits 6 --points 17 --out outputs_su2_n6
+```
+
+示例终端输出如下：
+
+```text
+SU(2) detector-response toy simulation 完成
+输出目录：outputs_su2_n6
+singlet-triplet gap 最小窗口：delta = -0.750000
+detector slope 诊断窗口：delta = -0.562500
+fidelity dip 诊断窗口：delta = -0.187500
+detector color correlation = -0.073882
+```
+
+### 2. 生成图表
+
+```bash
+python make_plots.py --input outputs_su2_n6/summary.json --out outputs_su2_n6/figures
+```
+
+### 3. 运行 tutorial 入口
+
+```bash
+python Tutorials/SU2DetectorResponseToy/run_tutorial.py --num-qubits 6 --points 17
+python Tutorials/SU2DetectorResponseToy/make_tutorial_plots.py
+```
+
+### 4. 运行 pyQPanda CPUQVM 示例
+
+```bash
+python pyqpanda_demo.py --num-qubits 6 --shots 1000
+```
+
+或：
+
+```bash
+python Tutorials/SU2DetectorResponseToy/pyqpanda_cpuqvm_example.py --num-qubits 6 --shots 1000
+```
+
+运行后会输出 bitstring counts，并保存为 JSON 文件。示例终端输出如下：
+
+```text
+pyQPanda CPUQVM SU(2) singlet-pair demo 完成
+输出文件：outputs_pyqpanda/counts.json
+非零 bitstring 数：...
+```
+
+## 输出文件
+
+运行扫描后会生成：
+
+```text
+su2_spectrum_scan.csv
+summary.json
+singlet_triplet_gap_chart.txt
+detector_slope_chart.txt
+fidelity_loss_chart.txt
+state_prep_singlet_pairs.qasm
+color_quench_probe.qasm
+```
+
+运行画图脚本后会生成：
+
+```text
+singlet_triplet_gap.png
+detector_color_correlation.png
+fidelity_loss.png
+quench_delta_energy.png
+summary_panels.png
+```
+
+图表含义：
+
+- `singlet_triplet_gap.png`：展示最低 singlet 与 triplet sector 的能量差随参数变化的趋势。
+- `detector_color_correlation.png`：展示左右 detector sites 的 connected color correlation。
+- `fidelity_loss.png`：展示相邻参数点之间 ground-state overlap 的变化。
+- `quench_delta_energy.png`：展示 central color-singlet quench 后的能量注入。
+- `summary_panels.png`：汇总主要诊断量，便于快速检查教程输出。
+
+## 数值诊断量与线路对应关系
+
+数值扫描用于生成参考观测量，pyQPanda / OpenQASM 部分用于展示可迁移的线路构造入口。
+
+| 数值或线路对象 | 物理含义 | 主要输出文件 | pyQPanda / OpenQASM 对应关系 |
+|---|---|---|---|
+| singlet-pair state preparation | SU(2) singlet 初态构造 | `state_prep_singlet_pairs.qasm` | pyQPanda 示例中的 pair preparation 线路 |
+| singlet/triplet sector energies | sector-resolved spectroscopy | `su2_spectrum_scan.csv`, `singlet_triplet_gap_chart.txt` | 作为后续 VQE 或谱测量线路的 reference observable |
+| central color-singlet quench response | 中心 bond 上的 SU(2)-scalar 局域扰动响应 | `summary.json`, `quench_delta_energy.png` | `color_quench_probe.qasm` 与 CPUQVM local probe circuit |
+| detector connected color correlation | 左右 detector sites 的 connected color response | `detector_slope_chart.txt`, `detector_color_correlation.png` | 给出后续 measurement circuit 的目标观测量 |
+| ground-state fidelity loss | 参数扫描中基态结构变化的参考诊断 | `fidelity_loss_chart.txt`, `fidelity_loss.png` | 可用于验证参数化线路扫描的一致性 |
+
+## 数学模型概述
+
+每个 qubit 表示一个 fundamental SU(2) color spin。两体相互作用取 SU(2)-scalar 形式：
+
+$$
+S_i \cdot S_j = \frac{X_i X_j + Y_i Y_j + Z_i Z_j}{4}
+$$
+
+模型 Hamiltonian 为：
+
+$$
+\begin{aligned}
+H(\delta)
+&= \sum_i J\left[1 + \delta(-1)^i\right] S_i \cdot S_{i+1} \\
+&\quad + \kappa \sum_{i<j} e^{-|i-j|/\xi} S_i \cdot S_j .
+\end{aligned}
+$$
+
+其中 $\delta$ 控制 dimerization，$\kappa$ 和 $\xi$ 控制长程 color interaction 的强度与衰减。
+
+## 项目亮点
+
+- 物理结构保留 SU(2) 对称性。
+- 输出 singlet/triplet sector resolved spectroscopy。
+- 以 connected color correlation 作为 detector-response 诊断量。
+- 示例规模小，便于教学、复现实验和算法展示。
+- 同时包含数值模拟、图表生成、OpenQASM 导出和 pyQPanda CPUQVM 示例。
+
+## 验证方式
+
+```bash
+python -m py_compile run_demo.py make_plots.py pyqpanda_demo.py
+python Tutorials/SU2DetectorResponseToy/run_tutorial.py --num-qubits 6 --points 17
+python Tutorials/SU2DetectorResponseToy/make_tutorial_plots.py
+python -c "import sys; sys.path.insert(0, 'tests'); import test_eec_toy as t; [getattr(t, n)() for n in dir(t) if n.startswith('test_')]; print('tests ok')"
+```

--- a/SU2DetectorResponseToy/SUBMISSION_CHECKLIST.md
+++ b/SU2DetectorResponseToy/SUBMISSION_CHECKLIST.md
@@ -1,0 +1,50 @@
+# 提交检查清单
+
+## PR 标题
+
+```text
+【创新应用】SU(2) detector-response toy simulation demo
+```
+
+## 文件清单
+
+- [x] `README.md`：项目总说明
+- [x] `contest_pitch.txt`：项目简介与应用场景
+- [x] `requirements.txt`：依赖列表
+- [x] `run_demo.py`：主扫描入口
+- [x] `make_plots.py`：图表生成入口
+- [x] `pyqpanda_demo.py`：pyQPanda CPUQVM 示例入口
+- [x] `src/eec_toy/`：SU(2) toy simulation 模块
+- [x] `tests/test_eec_toy.py`：基础测试
+- [x] `Tutorials/SU2DetectorResponseToy/README.md`：教程说明
+- [x] `Tutorials/SU2DetectorResponseToy/DERIVATION.md`：模型原理说明
+- [x] `Tutorials/SU2DetectorResponseToy/CONTRIBUTION_NOTE.md`：贡献说明
+- [x] `Tutorials/SU2DetectorResponseToy/PR_DESCRIPTION.md`：PR 正文草稿
+- [x] `Tutorials/SU2DetectorResponseToy/run_tutorial.py`：教程运行入口
+- [x] `Tutorials/SU2DetectorResponseToy/make_tutorial_plots.py`：教程画图入口
+- [x] `Tutorials/SU2DetectorResponseToy/pyqpanda_cpuqvm_example.py`：教程版 pyQPanda 示例
+
+## 本地验证命令
+
+```bash
+python -m py_compile run_demo.py make_plots.py pyqpanda_demo.py
+python -m py_compile Tutorials/SU2DetectorResponseToy/run_tutorial.py Tutorials/SU2DetectorResponseToy/make_tutorial_plots.py Tutorials/SU2DetectorResponseToy/pyqpanda_cpuqvm_example.py
+python Tutorials/SU2DetectorResponseToy/run_tutorial.py --num-qubits 6 --points 17
+python Tutorials/SU2DetectorResponseToy/make_tutorial_plots.py
+python -c "import sys; sys.path.insert(0, 'tests'); import test_eec_toy as t; [getattr(t, n)() for n in dir(t) if n.startswith('test_')]; print('tests ok')"
+```
+
+## 输出文件检查
+
+运行后生成的 `outputs/`、`outputs_su2_n6/`、`__pycache__/`、`*.pyc` 请排除在提交内容之外。
+
+## 提交前检查
+
+- [ ] README 可以独立说明项目目的与运行方式。
+- [ ] tutorial 文档可以独立运行。
+- [ ] `DERIVATION.md` 只说明模型原理与算法设计。
+- [ ] PR 正文使用中文为主，描述清楚教程定位、创新点、运行方式和测试方式。
+- [ ] README 已说明 `pyqpanda` 只用于 CPUQVM 示例，数值教程可用 NumPy 与 Matplotlib 运行。
+- [ ] README 已说明 NumPy reference、OpenQASM prototype 与 pyQPanda CPUQVM execution 的关系。
+- [ ] pyQPanda CPUQVM 示例说明了 bitstring counts 输出位置。
+- [ ] 提交内容不包含本地输出、缓存文件或个人配置。

--- a/SU2DetectorResponseToy/Tutorials/SU2DetectorResponseToy/.gitignore
+++ b/SU2DetectorResponseToy/Tutorials/SU2DetectorResponseToy/.gitignore
@@ -1,0 +1,4 @@
+outputs*/
+__pycache__/
+*.pyc
+*.pyo

--- a/SU2DetectorResponseToy/Tutorials/SU2DetectorResponseToy/CONTRIBUTION_NOTE.md
+++ b/SU2DetectorResponseToy/Tutorials/SU2DetectorResponseToy/CONTRIBUTION_NOTE.md
@@ -1,0 +1,82 @@
+# Contribution Note: SU(2) Detector Response Toy Simulation
+
+## PR 标题
+
+```text
+【创新应用】SU(2) detector-response toy simulation demo
+```
+
+## 提交类型
+
+```text
+创新应用 / quantum simulation example
+```
+
+## 项目概述
+
+本贡献提供一个小规模 SU(2)-对称量子多体模拟示例。项目使用 color-chain toy Hamiltonian 展示 SU(2)-scalar interaction、singlet/triplet sector spectroscopy、局域 color-singlet quench 和 detector connected color correlation。
+
+该示例面向教学、算法展示和 pyQPanda 线路迁移，默认规模为 4 到 8 个 qubit，可在本地快速运行。
+
+贡献定位为教程型创新应用：数值扫描部分提供参考观测量，pyQPanda CPUQVM 示例提供对应线路构造入口。
+
+## 主要内容
+
+1. `Tutorials/SU2DetectorResponseToy/README.md`
+   - 教程入口与运行方式。
+
+2. `Tutorials/SU2DetectorResponseToy/DERIVATION.md`
+   - SU(2) 模型原理、sector 诊断和 detector correlation 说明。
+
+3. `Tutorials/SU2DetectorResponseToy/run_tutorial.py`
+   - 运行 SU(2) spectrum / detector correlation 扫描。
+
+4. `Tutorials/SU2DetectorResponseToy/make_tutorial_plots.py`
+   - 根据扫描结果生成图表。
+
+5. `Tutorials/SU2DetectorResponseToy/pyqpanda_cpuqvm_example.py`
+   - pyQPanda CPUQVM 线路示例。
+
+6. `src/eec_toy/`
+   - 可复用 SU(2) toy simulation 模块。
+
+## 模型形式
+
+Hamiltonian 由 SU(2)-scalar interaction 构成：
+
+$$
+S_i \cdot S_j = \frac{X_i X_j + Y_i Y_j + Z_i Z_j}{4}
+$$
+
+扫描参数 $\delta$：
+
+$$
+\begin{aligned}
+H(\delta)
+&= \sum_i J\left[1 + \delta(-1)^i\right] S_i \cdot S_{i+1} \\
+&\quad + \kappa \sum_{i<j} e^{-|i-j|/\xi} S_i \cdot S_j .
+\end{aligned}
+$$
+
+核心输出包括：
+
+- singlet/triplet sector energies。
+- singlet-triplet gap。
+- ground-state fidelity loss。
+- central color-singlet quench response。
+- left-right detector connected color correlation。
+
+## 创新点
+
+- 使用 SU(2)-对称 toy model 展示 color-sector 诊断。
+- 将谱结构、局域 quench 和 detector correlation 放在同一个小规模示例中。
+- 同时提供数值扫描、图表、OpenQASM 线路和 pyQPanda CPUQVM 示例。
+- 示例规模小，便于复现和教学。
+
+## 本地验证
+
+```bash
+python Tutorials/SU2DetectorResponseToy/run_tutorial.py --num-qubits 6 --points 17
+python Tutorials/SU2DetectorResponseToy/make_tutorial_plots.py
+python -c "import sys; sys.path.insert(0, 'tests'); import test_eec_toy as t; [getattr(t, n)() for n in dir(t) if n.startswith('test_')]; print('tests ok')"
+```

--- a/SU2DetectorResponseToy/Tutorials/SU2DetectorResponseToy/DERIVATION.md
+++ b/SU2DetectorResponseToy/Tutorials/SU2DetectorResponseToy/DERIVATION.md
@@ -1,0 +1,157 @@
+# SU(2) Detector Response Toy Simulation：模型原理说明
+
+## 1. 目标
+
+本教程构造一个小规模 SU(2)-对称量子多体模拟示例，用于展示以下内容：
+
+1. qubit 上的 fundamental color spin 表示。
+2. SU(2)-scalar interaction 的 Hamiltonian 构造。
+3. singlet / triplet sector 的能谱诊断。
+4. color-singlet local quench 的线路含义。
+5. detector connected color correlation 的计算。
+
+该示例保持模型规模较小，适合教学、算法展示和 pyQPanda CPUQVM 运行。
+
+## 2. qubit 与 SU(2) color spin
+
+每个 qubit 表示一个 spin-1/2 color degree of freedom。单个 site 上定义：
+
+$$
+S_a(i) = \frac{\sigma_a(i)}{2}, \qquad a \in \{x, y, z\} .
+$$
+
+其中 $\sigma_a$ 是 Pauli operator。两个 site 的 SU(2)-scalar interaction 定义为：
+
+$$
+\begin{aligned}
+\mathbf{S}(i) \cdot \mathbf{S}(j)
+&= S_x(i)S_x(j) + S_y(i)S_y(j) + S_z(i)S_z(j) \\
+&= \frac{X_i X_j + Y_i Y_j + Z_i Z_j}{4} .
+\end{aligned}
+$$
+
+该相互作用在全局 SU(2) rotation 下保持不变，因此适合用作 SU(2)-对称量子多体示例的基本 building block。
+
+## 3. Toy Hamiltonian
+
+教程使用的 Hamiltonian 为：
+
+$$
+\begin{aligned}
+H(\delta)
+&= \sum_i J\left[1 + \delta(-1)^i\right] \mathbf{S}_i \cdot \mathbf{S}_{i+1} \\
+&\quad + \kappa \sum_{i<j} e^{-|i-j|/\xi} \mathbf{S}_i \cdot \mathbf{S}_j .
+\end{aligned}
+$$
+
+参数含义：
+
+- `J`：最近邻 color exchange coupling。
+- $\delta$：dimerization 参数，用于调节奇偶 bond 的强度。
+- $\kappa$：长程 color interaction 强度。
+- $\xi$：长程 interaction 的衰减长度。
+
+第一项描述 dimerized SU(2) color chain。第二项提供一个随距离衰减的长程 color interaction，使示例不仅包含最近邻交换，也能展示更丰富的谱结构变化。
+
+## 4. singlet / triplet sector 诊断
+
+SU(2) 模型的重要信息之一是态所属的 total spin sector。定义：
+
+$$
+\mathbf{S}_{\mathrm{tot}} = \sum_i \mathbf{S}_i .
+$$
+
+Casimir operator 为：
+
+$$
+\begin{aligned}
+\mathbf{S}_{\mathrm{tot}}^2
+&= \sum_i \mathbf{S}_i^2 + 2\sum_{i<j} \mathbf{S}_i \cdot \mathbf{S}_j \\
+&= \frac{3N}{4} + 2\sum_{i<j} \mathbf{S}_i \cdot \mathbf{S}_j .
+\end{aligned}
+$$
+
+如果一个本征态属于 spin-S sector，则：
+
+$$
+\mathbf{S}_{\mathrm{tot}}^2 = S(S+1) .
+$$
+
+因此可以从 $\mathbf{S}_{\mathrm{tot}}^2$ 的期望值估计 sector：
+
+$$
+S = \frac{-1 + \sqrt{1 + 4\langle \mathbf{S}_{\mathrm{tot}}^2 \rangle}}{2} .
+$$
+
+在输出中：
+
+- $S \approx 0$ 对应 singlet sector。
+- $S \approx 1$ 对应 triplet sector。
+- `singlet_triplet_gap` 表示最低 singlet 与最低 triplet 的能量差，即 $E_{\mathrm{triplet}} - E_{\mathrm{singlet}}$。
+
+## 5. color-singlet local quench
+
+局域 quench 作用在中心 bond 上，使用 SU(2)-scalar operator：
+
+$$
+O_q = \mathbf{S}_c \cdot \mathbf{S}_{c+1} .
+$$
+
+对应 unitary：
+
+$$
+U_q(\theta) = \exp\left(-i\theta O_q\right) .
+$$
+
+该 quench 与 Hamiltonian 使用相同的 SU(2)-scalar building block，适合展示中心局域扰动对低能谱权重的影响。
+
+代码记录 quench 后能量注入：
+
+$$
+\Delta E = \langle \psi_q | H | \psi_q \rangle - E_0 .
+$$
+
+以及低能级 spectral weights：
+
+$$
+w_n = \left|\langle E_n | \psi_q \rangle\right|^2 .
+$$
+
+## 6. detector connected color correlation
+
+左右 detector site 的 connected color correlation 定义为：
+
+$$
+\begin{aligned}
+C_{LR}
+&= \sum_a \left[\langle S_a(L)S_a(R)\rangle - \langle S_a(L)\rangle\langle S_a(R)\rangle\right] \\
+&= \langle \mathbf{S}(L) \cdot \mathbf{S}(R) \rangle - \langle \mathbf{S}(L) \rangle \cdot \langle \mathbf{S}(R) \rangle .
+\end{aligned}
+$$
+
+该量是 SU(2)-scalar observable，可用于展示两个空间分离位置之间的 connected correlation。代码还会计算 $C_{LR}$ 随 $\delta$ 变化的最大斜率窗口，用于定位有限尺寸系统中的关联结构变化区域。
+
+## 7. 运行输出
+
+默认 6-qubit 示例会输出：
+
+```text
+minimum_singlet_triplet_gap
+crossover_by_detector_slope
+crossover_by_fidelity_dip
+largest_singlet_quench_response
+```
+
+这些结果用于展示 SU(2)-对称 color-chain 中的能谱结构、态保真度变化、局域 quench 响应和 detector connected correlation。
+
+## 8. 小规模模拟中的技术点
+
+本示例虽然规模较小，但仍包含若干量子模拟中的关键技术点：
+
+1. Hamiltonian 由多个 Pauli-string 组合而成。
+2. sector 诊断需要额外构造 $\mathbf{S}_{\mathrm{tot}}^2$。
+3. connected correlation 需要组合 one-point 和 two-point expectation values。
+4. quench 后态需要投影到能量本征态以分析 spectral weights。
+5. pyQPanda 示例需要将态制备和 quench probe 写成可执行线路。
+
+这些设计使该项目既可作为物理模型示例，也可作为量子线路构造与观测量分析的教学案例。

--- a/SU2DetectorResponseToy/Tutorials/SU2DetectorResponseToy/PR_DESCRIPTION.md
+++ b/SU2DetectorResponseToy/Tutorials/SU2DetectorResponseToy/PR_DESCRIPTION.md
@@ -1,0 +1,62 @@
+# PR 正文草稿
+
+## 标题
+
+```text
+【创新应用】SU(2) detector-response toy simulation demo
+```
+
+## 概要
+
+本 PR 新增一个自包含的 SU(2)-对称量子模拟教程示例，并提供 pyQPanda CPUQVM 线路构造示例。
+
+数值部分通过小规模 color-chain toy Hamiltonian 的精确对角化生成参考观测量；pyQPanda 示例使用 CPUQVM 构造并运行对应的 singlet 态制备与局域 probe 线路；OpenQASM 文件提供可迁移线路原型。该示例适合作为量子多体模拟、SU(2) sector 诊断和 pyQPanda CPUQVM 入门教程。
+
+## 主要内容
+
+- `Tutorials/SU2DetectorResponseToy/README.md`：教程入口与运行说明。
+- `DERIVATION.md`：说明 SU(2)-scalar interaction、sector 诊断、局域 quench 与 connected correlation。
+- `run_tutorial.py`：运行 4 到 8 个 qubit 的小规模有限尺寸扫描。
+- `make_tutorial_plots.py`：根据扫描结果生成诊断图表。
+- `pyqpanda_cpuqvm_example.py`：pyQPanda CPUQVM 线路原型，可运行并输出 bitstring counts。
+- README 中补充赛事指定工具使用说明，以及数值诊断量、输出文件与 pyQPanda / OpenQASM 线路的对应关系。
+- `src/eec_toy/`：教程使用的可复用 toy-model 工具。
+- `tests/test_eec_toy.py`：基础正确性检查。
+
+## 教程输出
+
+教程会输出以下诊断量：
+
+- singlet/triplet sector energies。
+- singlet-triplet gap。
+- ground-state fidelity loss。
+- central color-singlet quench energy injection。
+- left-right detector connected color correlation。
+- 态制备与局域 probe 线路的 OpenQASM 原型。
+
+## 运行方式
+
+```bash
+python Tutorials/SU2DetectorResponseToy/run_tutorial.py --num-qubits 6 --points 17
+python Tutorials/SU2DetectorResponseToy/make_tutorial_plots.py
+```
+
+可选 pyQPanda CPUQVM 示例：
+
+```bash
+python Tutorials/SU2DetectorResponseToy/pyqpanda_cpuqvm_example.py --num-qubits 6 --shots 1000
+```
+
+`pyqpanda` 只用于 CPUQVM 示例。数值教程部分只需要 NumPy 与 Matplotlib 即可运行。
+
+## 测试方式
+
+- 编译检查所有 Python 脚本。
+- 运行 6-qubit、17 个参数点的 tutorial scan。
+- 根据 `summary.json` 生成图表。
+- 运行 pyQPanda CPUQVM 示例，验证 singlet-pair preparation 与 local probe circuit 可执行，并输出 bitstring counts。
+- 运行基础测试，检查 Hermiticity、sector diagnostics、quench normalization、scan summary fields 和 QASM circuit shape。
+
+## 说明
+
+生成的输出目录与 Python 缓存文件已通过 `.gitignore` 排除。

--- a/SU2DetectorResponseToy/Tutorials/SU2DetectorResponseToy/README.md
+++ b/SU2DetectorResponseToy/Tutorials/SU2DetectorResponseToy/README.md
@@ -1,0 +1,173 @@
+# SU(2) Detector Response Toy Simulation Tutorial
+
+## 简介
+
+本教程展示一个小规模 SU(2)-对称量子多体模拟示例。模型以 qubit 表示 fundamental color spin，通过 SU(2)-scalar interaction 构造 color-chain Hamiltonian，并输出 singlet/triplet sector spectroscopy、局域 quench response 与 detector connected color correlation。
+
+该教程适合作为量子算法创新应用、量子多体模拟教学和 pyQPanda CPUQVM 线路示例。数值教程只依赖 NumPy 与 Matplotlib；pyQPanda 只用于 CPUQVM 线路示例。
+
+## 赛事指定工具使用说明
+
+本教程使用 pyQPanda CPUQVM 构造并运行 singlet-pair preparation 与 central color-quench probe 线路。数值扫描提供参考观测量，pyQPanda 示例提供可执行线路，OpenQASM 文件提供可迁移线路原型。
+
+```text
+NumPy reference scan -> OpenQASM circuit prototype -> pyQPanda CPUQVM execution
+```
+
+## 任务类型
+
+```text
+【创新应用】SU(2) detector-response toy simulation demo
+```
+
+## 流程概览
+
+```text
+SU(2)-symmetric color-chain Hamiltonian
+-> singlet ground state
+-> singlet/triplet sector spectrum
+-> central color-singlet quench
+-> spectral weight redistribution
+-> detector connected color correlation
+-> OpenQASM / pyQPanda CPUQVM prototype
+```
+
+## 文件说明
+
+```text
+Tutorials/SU2DetectorResponseToy/
+├── README.md
+├── DERIVATION.md
+├── CONTRIBUTION_NOTE.md
+├── PR_DESCRIPTION.md
+├── run_tutorial.py
+├── make_tutorial_plots.py
+└── pyqpanda_cpuqvm_example.py
+```
+
+可复用代码位于：
+
+```text
+src/eec_toy/
+```
+
+## 运行教程扫描
+
+在项目根目录执行：
+
+```bash
+python Tutorials/SU2DetectorResponseToy/run_tutorial.py --num-qubits 6 --points 17
+```
+
+默认输出到：
+
+```text
+Tutorials/SU2DetectorResponseToy/outputs/
+```
+
+示例终端输出：
+
+```text
+SU(2) detector-response toy simulation 完成
+输出目录：Tutorials/SU2DetectorResponseToy/outputs
+singlet-triplet gap 最小窗口：delta = -0.750000
+detector slope 诊断窗口：delta = -0.562500
+fidelity dip 诊断窗口：delta = -0.187500
+detector color correlation = -0.073882
+```
+
+主要输出：
+
+```text
+su2_spectrum_scan.csv
+summary.json
+singlet_triplet_gap_chart.txt
+detector_slope_chart.txt
+fidelity_loss_chart.txt
+state_prep_singlet_pairs.qasm
+color_quench_probe.qasm
+```
+
+## 生成图表
+
+```bash
+python Tutorials/SU2DetectorResponseToy/make_tutorial_plots.py
+```
+
+图表输出到：
+
+```text
+Tutorials/SU2DetectorResponseToy/outputs/figures/
+```
+
+包括：
+
+```text
+singlet_triplet_gap.png
+detector_color_correlation.png
+fidelity_loss.png
+quench_delta_energy.png
+summary_panels.png
+```
+
+这些图分别对应 sector gap、detector connected correlation、fidelity loss、quench energy injection 和汇总诊断面板。
+
+## 数值诊断量与线路对应关系
+
+| 数值或线路对象 | 教程作用 | 主要输出文件 | pyQPanda / OpenQASM 对应关系 |
+|---|---|---|---|
+| singlet-pair state preparation | 构造 SU(2) singlet 初态 | `state_prep_singlet_pairs.qasm` | pyQPanda CPUQVM 示例中的 pair preparation 线路 |
+| singlet/triplet sector energies | 展示 sector-resolved spectroscopy | `su2_spectrum_scan.csv`, `singlet_triplet_gap_chart.txt` | 为后续 VQE 或谱测量线路提供参考量 |
+| central color-singlet quench response | 展示中心 bond 局域扰动后的能量注入 | `summary.json`, `quench_delta_energy.png` | `color_quench_probe.qasm` 与 CPUQVM local probe circuit |
+| detector connected color correlation | 展示左右 detector sites 的 connected response | `detector_slope_chart.txt`, `detector_color_correlation.png` | 给出后续 measurement circuit 的目标观测量 |
+| ground-state fidelity loss | 展示参数扫描下基态结构变化 | `fidelity_loss_chart.txt`, `fidelity_loss.png` | 可用于验证参数化线路扫描的一致性 |
+
+## pyQPanda CPUQVM 示例
+
+```bash
+python Tutorials/SU2DetectorResponseToy/pyqpanda_cpuqvm_example.py --num-qubits 6 --shots 1000
+```
+
+该脚本展示 singlet-pair preparation 与 central color-quench probe 的 pyQPanda 线路构造方式。运行后会输出 CPUQVM bitstring counts，并保存到：
+
+```text
+Tutorials/SU2DetectorResponseToy/outputs/pyqpanda_counts.json
+```
+
+示例终端输出：
+
+```text
+pyQPanda CPUQVM SU(2) singlet-pair demo 完成
+输出文件：Tutorials/SU2DetectorResponseToy/outputs/pyqpanda_counts.json
+非零 bitstring 数：...
+```
+
+## 理论说明
+
+见：
+
+```text
+DERIVATION.md
+```
+
+该文档说明：
+
+- SU(2)-scalar interaction 的构造。
+- singlet/triplet sector 的识别方式。
+- color-singlet quench 的线路含义。
+- detector connected color correlation 的计算方式。
+- 小规模量子模拟示例中的建模与测量难点。
+
+## 示例输出摘要
+
+默认 6-qubit 示例会输出：
+
+```text
+minimum singlet-triplet gap position
+crossover window by detector-correlation slope
+crossover window by fidelity loss
+quench energy injection
+connected detector color correlation
+```
+
+这些量用于展示有限尺寸 SU(2) color-chain 中的谱结构与关联结构变化。

--- a/SU2DetectorResponseToy/Tutorials/SU2DetectorResponseToy/make_tutorial_plots.py
+++ b/SU2DetectorResponseToy/Tutorials/SU2DetectorResponseToy/make_tutorial_plots.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from make_plots import main as make_plots_main
+
+
+if __name__ == "__main__":
+    here = Path(__file__).resolve().parent
+    if "--input" not in sys.argv:
+        sys.argv.extend(["--input", str(here / "outputs" / "summary.json")])
+    if "--out" not in sys.argv:
+        sys.argv.extend(["--out", str(here / "outputs" / "figures")])
+    make_plots_main()

--- a/SU2DetectorResponseToy/Tutorials/SU2DetectorResponseToy/pyqpanda_cpuqvm_example.py
+++ b/SU2DetectorResponseToy/Tutorials/SU2DetectorResponseToy/pyqpanda_cpuqvm_example.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from pyqpanda_demo import main as pyqpanda_demo_main
+
+
+if __name__ == "__main__":
+    default_out = str(Path(__file__).resolve().parent / "outputs" / "pyqpanda_counts.json")
+    if "--out" not in sys.argv:
+        sys.argv.extend(["--out", default_out])
+    pyqpanda_demo_main()

--- a/SU2DetectorResponseToy/Tutorials/SU2DetectorResponseToy/run_tutorial.py
+++ b/SU2DetectorResponseToy/Tutorials/SU2DetectorResponseToy/run_tutorial.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from run_demo import main as run_demo_main
+
+
+if __name__ == "__main__":
+    default_out = str(Path(__file__).resolve().parent / "outputs")
+    if "--out" not in sys.argv:
+        sys.argv.extend(["--out", default_out])
+    run_demo_main()

--- a/SU2DetectorResponseToy/contest_pitch.txt
+++ b/SU2DetectorResponseToy/contest_pitch.txt
@@ -1,0 +1,24 @@
+项目名：SU(2) Detector Response Toy Simulation
+
+任务类型：创新应用
+
+项目简介：
+本项目实现了一个小规模 SU(2)-对称量子多体模拟示例，用于展示 singlet 态制备、singlet/triplet sector 能谱分析、局域 color-singlet quench 和 detector connected color correlation。项目默认使用 4 到 8 个 qubit，可在本地快速复现，并提供 OpenQASM 与 pyQPanda CPUQVM 示例入口。
+
+核心展示：
+1. 使用 SU(2)-scalar interaction $S_i \cdot S_j$ 构造 color-chain toy Hamiltonian。
+2. 扫描 dimerization 参数 $\delta$，展示低能谱结构变化。
+3. 使用 total spin $\mathbf{S}_{\mathrm{tot}}^2$ 识别 singlet / triplet sector。
+4. 在中心 bond 施加 color-singlet quench，观察能量注入与低能级权重重排。
+5. 计算左右 detector site 的 connected color correlation。
+6. 导出 singlet-pair preparation 和 color-quench probe 的 OpenQASM 原型。
+7. 提供 pyQPanda CPUQVM 示例，便于量子线路学习与迁移。
+
+适用场景：
+- 量子多体模拟教学示例。
+- SU(2) 对称性与 sector spectroscopy 演示。
+- connected correlation 与 detector-response 类观测量演示。
+- pyQPanda / OpenQASM 线路构造示例。
+
+推荐 PR 标题：
+【创新应用】SU(2) detector-response toy simulation demo

--- a/SU2DetectorResponseToy/make_plots.py
+++ b/SU2DetectorResponseToy/make_plots.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+
+def load_rows(path: Path) -> list[dict[str, Any]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    rows = payload.get("rows", [])
+    if not rows:
+        raise SystemExit(f"没有在 {path} 中找到 rows 数据。")
+    return rows
+
+
+def values(rows: list[dict[str, Any]], key: str) -> list[float]:
+    return [float(row[key]) for row in rows]
+
+
+def plot_line(rows: list[dict[str, Any]], y_key: str, ylabel: str, title: str, out_path: Path) -> None:
+    x = values(rows, "delta")
+    y = values(rows, y_key)
+    fig, ax = plt.subplots(figsize=(7.0, 4.4), dpi=150)
+    ax.plot(x, y, marker="o", linewidth=1.8, markersize=4)
+    ax.set_xlabel("dimerization delta")
+    ax.set_ylabel(ylabel)
+    ax.set_title(title)
+    ax.grid(True, alpha=0.28)
+    fig.tight_layout()
+    fig.savefig(out_path)
+    plt.close(fig)
+
+
+def plot_summary_panels(rows: list[dict[str, Any]], out_path: Path) -> None:
+    x = values(rows, "delta")
+    panels = [
+        ("singlet_triplet_gap", "singlet-triplet gap"),
+        ("detector_color_conn", "detector color correlation"),
+        ("fidelity_loss_to_previous", "ground-state fidelity loss"),
+        ("quench_delta_e", "quench energy injection"),
+    ]
+    fig, axes = plt.subplots(2, 2, figsize=(10.0, 7.2), dpi=150, sharex=True)
+    for ax, (key, title) in zip(axes.flatten(), panels):
+        ax.plot(x, values(rows, key), marker="o", linewidth=1.6, markersize=3.5)
+        ax.set_title(title)
+        ax.set_xlabel("delta")
+        ax.grid(True, alpha=0.28)
+    fig.suptitle("SU(2) detector-response toy diagnostics", y=0.995)
+    fig.tight_layout()
+    fig.savefig(out_path)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", default="originq_eec_toy_demo/outputs_su2_n6/summary.json")
+    parser.add_argument("--out", default="originq_eec_toy_demo/outputs_su2_n6/figures")
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    rows = load_rows(input_path)
+
+    plot_line(rows, "singlet_triplet_gap", "E_triplet - E_singlet", "SU(2) singlet-triplet gap", out_dir / "singlet_triplet_gap.png")
+    plot_line(rows, "detector_color_conn", "connected color correlation", "left-right detector color correlation", out_dir / "detector_color_correlation.png")
+    plot_line(rows, "fidelity_loss_to_previous", "1 - fidelity", "ground-state fidelity loss", out_dir / "fidelity_loss.png")
+    plot_line(rows, "quench_delta_e", "Delta E after quench", "central color-singlet quench response", out_dir / "quench_delta_energy.png")
+    plot_summary_panels(rows, out_dir / "summary_panels.png")
+
+    print("SU(2) demo 图表已生成")
+    print(f"输出目录：{out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/SU2DetectorResponseToy/pyqpanda_demo.py
+++ b/SU2DetectorResponseToy/pyqpanda_demo.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_pyqpanda() -> Any:
+    try:
+        import pyqpanda as pq
+    except Exception as exc:
+        raise SystemExit("未安装 pyqpanda。请先运行：py -3 -m pip install pyqpanda") from exc
+    return pq
+
+
+def insert_gate(prog: Any, gate: Any) -> Any:
+    method = getattr(prog, "insert", None)
+    if callable(method):
+        return method(gate)
+    return prog << gate
+
+
+def build_singlet_pair_program(pq: Any, qubits: list[Any], cbits: list[Any], theta: float, with_quench: bool) -> Any:
+    prog = pq.QProg()
+    for left in range(0, len(qubits), 2):
+        right = left + 1
+        insert_gate(prog, pq.X(qubits[right]))
+        insert_gate(prog, pq.H(qubits[left]))
+        insert_gate(prog, pq.CNOT(qubits[left], qubits[right]))
+        insert_gate(prog, pq.Z(qubits[left]))
+
+    if with_quench:
+        center_left = len(qubits) // 2 - 1
+        center_right = len(qubits) // 2
+        insert_gate(prog, pq.CNOT(qubits[center_left], qubits[center_right]))
+        insert_gate(prog, pq.RZ(qubits[center_right], theta))
+        insert_gate(prog, pq.CNOT(qubits[center_left], qubits[center_right]))
+
+    measure = getattr(pq, "Measure", None)
+    if callable(measure):
+        for qubit, cbit in zip(qubits, cbits):
+            insert_gate(prog, measure(qubit, cbit))
+        return prog
+
+    measure_all = getattr(pq, "measure_all", None)
+    if callable(measure_all):
+        insert_gate(prog, measure_all(qubits, cbits))
+        return prog
+
+    raise RuntimeError("pyqpanda 未找到 Measure 或 measure_all")
+
+
+def run_cpuqvm(num_qubits: int, shots: int, theta: float, with_quench: bool) -> dict[str, Any]:
+    pq = load_pyqpanda()
+    qvm = pq.CPUQVM()
+    qvm.init_qvm()
+    try:
+        qubits = qvm.qAlloc_many(num_qubits)
+        cbits = qvm.cAlloc_many(num_qubits)
+        prog = build_singlet_pair_program(pq, qubits, cbits, theta, with_quench)
+        result = qvm.run_with_configuration(prog, cbits, shots)
+        return {
+            "num_qubits": num_qubits,
+            "shots": shots,
+            "theta": theta,
+            "with_quench": with_quench,
+            "counts": dict(result),
+        }
+    finally:
+        finalize = getattr(qvm, "finalize", None)
+        if callable(finalize):
+            finalize()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--num-qubits", type=int, default=6)
+    parser.add_argument("--shots", type=int, default=1000)
+    parser.add_argument("--theta", type=float, default=0.35)
+    parser.add_argument("--no-quench", action="store_true")
+    parser.add_argument("--out", default="originq_eec_toy_demo/outputs_pyqpanda/counts.json")
+    args = parser.parse_args()
+
+    if args.num_qubits < 2 or args.num_qubits % 2 != 0:
+        raise SystemExit("num-qubits 必须是大于等于 2 的偶数。")
+    if args.shots <= 0:
+        raise SystemExit("shots 必须为正整数。")
+
+    payload = run_cpuqvm(args.num_qubits, args.shots, args.theta, with_quench=not args.no_quench)
+    path = Path(args.out)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    print("pyQPanda CPUQVM SU(2) singlet-pair demo 完成")
+    print(f"输出文件：{path}")
+    print(f"非零 bitstring 数：{len(payload['counts'])}")
+
+
+if __name__ == "__main__":
+    main()

--- a/SU2DetectorResponseToy/requirements.txt
+++ b/SU2DetectorResponseToy/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+matplotlib
+pyqpanda

--- a/SU2DetectorResponseToy/run_demo.py
+++ b/SU2DetectorResponseToy/run_demo.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from eec_toy.io_utils import ascii_gap_chart, ascii_metric_chart, write_csv, write_json, write_text
+from eec_toy.model import ToyConfig
+from eec_toy.qasm_export import singlet_pair_state_prep_qasm, su2_color_quench_probe_qasm
+from eec_toy.scan import scan_parameter_grid, summarize_scan
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--num-qubits", type=int, default=6)
+    parser.add_argument("--delta-min", type=float, default=-0.75)
+    parser.add_argument("--delta-max", type=float, default=0.75)
+    parser.add_argument("--points", type=int, default=25)
+    parser.add_argument("--theta", type=float, default=0.35)
+    parser.add_argument("--electric-kappa", type=float, default=0.12)
+    parser.add_argument("--axial-decay", type=float, default=2.5)
+    parser.add_argument("--periodic", action="store_true")
+    parser.add_argument("--out", default=str(ROOT / "outputs"))
+    args = parser.parse_args()
+
+    if args.num_qubits < 2 or args.num_qubits > 10 or args.num_qubits % 2 != 0:
+        raise SystemExit("建议 num-qubits 取 2、4、6、8、10；更大系统请先改用稀疏矩阵。")
+    if args.points < 3:
+        raise SystemExit("points 至少为 3。")
+    if abs(args.delta_min) >= 1.0 or abs(args.delta_max) >= 1.0:
+        raise SystemExit("为保持反铁磁 SU(2) bond，建议 delta 范围在 (-1, 1) 内。")
+
+    out_dir = Path(args.out)
+    config = ToyConfig(num_qubits=args.num_qubits, electric_kappa=args.electric_kappa, axial_decay=args.axial_decay, periodic=args.periodic)
+    delta_values = np.linspace(args.delta_min, args.delta_max, args.points)
+    rows = scan_parameter_grid(config, delta_values, quench_theta=args.theta)
+    summary = summarize_scan(config, rows)
+
+    write_csv(out_dir / "su2_spectrum_scan.csv", rows)
+    write_json(out_dir / "summary.json", {"summary": summary, "rows": rows})
+    write_text(out_dir / "singlet_triplet_gap_chart.txt", ascii_gap_chart(rows))
+    write_text(out_dir / "detector_slope_chart.txt", ascii_metric_chart(rows, "detector_conn_abs_slope", "SU(2) detector color-correlation slope"))
+    write_text(out_dir / "fidelity_loss_chart.txt", ascii_metric_chart(rows, "fidelity_loss_to_previous", "SU(2) ground-state fidelity loss between adjacent delta values"))
+    write_text(out_dir / "state_prep_singlet_pairs.qasm", singlet_pair_state_prep_qasm(args.num_qubits))
+    write_text(out_dir / "color_quench_probe.qasm", su2_color_quench_probe_qasm(args.num_qubits))
+
+    print("SU(2) detector-response toy simulation 完成")
+    print(f"输出目录：{out_dir}")
+    print(f"singlet-triplet gap 最小窗口：delta = {float(summary['minimum_singlet_triplet_gap']['delta']):.6f}")
+    print(f"detector slope 诊断窗口：delta = {float(summary['crossover_by_detector_slope']['delta']):.6f}")
+    print(f"fidelity dip 诊断窗口：delta = {float(summary['crossover_by_fidelity_dip']['delta']):.6f}")
+    print(f"detector color correlation = {float(summary['crossover_by_detector_slope']['detector_color_conn']):.6f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/SU2DetectorResponseToy/src/eec_toy/__init__.py
+++ b/SU2DetectorResponseToy/src/eec_toy/__init__.py
@@ -1,0 +1,11 @@
+from .model import ToyConfig, central_quench, connected_detector_correlation, ground_state, hamiltonian
+from .scan import scan_parameter_grid
+
+__all__ = [
+    "ToyConfig",
+    "central_quench",
+    "connected_detector_correlation",
+    "ground_state",
+    "hamiltonian",
+    "scan_parameter_grid",
+]

--- a/SU2DetectorResponseToy/src/eec_toy/io_utils.py
+++ b/SU2DetectorResponseToy/src/eec_toy/io_utils.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Any
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = list(rows[0].keys())
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            out = dict(row)
+            for key, value in out.items():
+                if isinstance(value, (list, dict)):
+                    out[key] = json.dumps(value)
+            writer.writerow(out)
+
+
+def ascii_metric_chart(rows: list[dict[str, Any]], metric: str, title: str, x_key: str = "delta", width: int = 42) -> str:
+    values = [abs(float(row[metric])) for row in rows]
+    max_value = max(values) if values else 1.0
+    lines = [title, f"{x_key:<9} {metric:<24} chart"]
+    for row, value in zip(rows, values):
+        raw = float(row[metric])
+        bar_len = int(width * value / max_value) if max_value > 0 else 0
+        lines.append(f"{float(row[x_key]):9.4f} {raw:24.9f}  " + "█" * max(1, bar_len))
+    return "\n".join(lines) + "\n"
+
+
+def ascii_gap_chart(rows: list[dict[str, Any]], width: int = 42) -> str:
+    return ascii_metric_chart(rows, "singlet_triplet_gap", "SU(2) singlet-triplet spectral gap", width=width)
+
+
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")

--- a/SU2DetectorResponseToy/src/eec_toy/model.py
+++ b/SU2DetectorResponseToy/src/eec_toy/model.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from .operators import X, Y, Z, expectation, normalize, pair_operator, site_operator
+
+
+@dataclass(frozen=True)
+class ToyConfig:
+    num_qubits: int = 6
+    exchange_j: float = 1.0
+    electric_kappa: float = 0.12
+    axial_decay: float = 2.5
+    periodic: bool = False
+
+
+def spin_component(num_qubits: int, site: int, pauli: np.ndarray) -> np.ndarray:
+    return 0.5 * site_operator(num_qubits, site, pauli)
+
+
+def color_dot_operator(num_qubits: int, left: int, right: int) -> np.ndarray:
+    return 0.25 * (
+        pair_operator(num_qubits, left, X, right, X)
+        + pair_operator(num_qubits, left, Y, right, Y)
+        + pair_operator(num_qubits, left, Z, right, Z)
+    )
+
+
+def total_spin_squared_operator(config: ToyConfig) -> np.ndarray:
+    n = config.num_qubits
+    s2 = 0.75 * n * np.eye(2**n, dtype=complex)
+    for i in range(n):
+        for j in range(i + 1, n):
+            s2 += 2.0 * color_dot_operator(n, i, j)
+    return s2
+
+
+def hamiltonian(config: ToyConfig, dimer_delta: float) -> np.ndarray:
+    n = config.num_qubits
+    dim = 2**n
+    h = np.zeros((dim, dim), dtype=complex)
+    for i in range(n - 1):
+        bond = config.exchange_j * (1.0 + dimer_delta * ((-1.0) ** i))
+        h += bond * color_dot_operator(n, i, i + 1)
+    if config.periodic and n > 2:
+        bond = config.exchange_j * (1.0 + dimer_delta * ((-1.0) ** (n - 1)))
+        h += bond * color_dot_operator(n, n - 1, 0)
+    if config.electric_kappa != 0.0:
+        for i in range(n):
+            for j in range(i + 1, n):
+                distance = j - i
+                kernel = np.exp(-distance / max(config.axial_decay, 1e-9))
+                h += config.electric_kappa * kernel * color_dot_operator(n, i, j)
+    return h
+
+
+def ground_state(h: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    values, vectors = np.linalg.eigh(h)
+    order = np.argsort(values.real)
+    return values[order].real, vectors[:, order[0]]
+
+
+def apply_singlet_quench(state: np.ndarray, config: ToyConfig, theta: float) -> np.ndarray:
+    n = config.num_qubits
+    left = max(0, n // 2 - 1)
+    right = min(n - 1, n // 2)
+    generator = color_dot_operator(n, left, right)
+    values, vectors = np.linalg.eigh(generator)
+    phases = np.exp(-1j * theta * values)
+    return normalize(vectors @ (phases * (vectors.conjugate().T @ state)))
+
+
+def central_quench(state: np.ndarray, config: ToyConfig, theta: float) -> np.ndarray:
+    return apply_singlet_quench(state, config, theta)
+
+
+def detector_sites(config: ToyConfig) -> tuple[int, int]:
+    n = config.num_qubits
+    if n < 4:
+        return 0, n - 1
+    return max(0, n // 2 - 2), min(n - 1, n // 2 + 1)
+
+
+def connected_detector_correlation(state: np.ndarray, config: ToyConfig) -> float:
+    n = config.num_qubits
+    left, right = detector_sites(config)
+    conn = 0.0
+    for pauli in (X, Y, Z):
+        sl = spin_component(n, left, pauli)
+        sr = spin_component(n, right, pauli)
+        conn += (expectation(state, sl @ sr) - expectation(state, sl) * expectation(state, sr)).real
+    return float(conn)
+
+
+def total_spin_expectation(state: np.ndarray, config: ToyConfig) -> float:
+    return float(expectation(state, total_spin_squared_operator(config)).real)
+
+
+def spin_from_s2(s2_value: float) -> float:
+    return float(max(0.0, (-1.0 + np.sqrt(max(0.0, 1.0 + 4.0 * s2_value))) / 2.0))
+
+
+def energy(state: np.ndarray, h: np.ndarray) -> float:
+    return float(expectation(state, h).real)
+
+
+def spectral_weights(state: np.ndarray, h: np.ndarray, levels: int) -> list[float]:
+    values, vectors = np.linalg.eigh(h)
+    order = np.argsort(values.real)
+    vectors = vectors[:, order[:levels]]
+    return [float(abs(np.vdot(vectors[:, i], state)) ** 2) for i in range(vectors.shape[1])]
+
+
+def spectrum_spin_table(h: np.ndarray, config: ToyConfig, levels: int) -> list[dict[str, float]]:
+    values, vectors = np.linalg.eigh(h)
+    order = np.argsort(values.real)
+    values = values[order].real
+    vectors = vectors[:, order]
+    s2_op = total_spin_squared_operator(config)
+    table = []
+    for i in range(min(levels, len(values))):
+        s2_value = float(expectation(vectors[:, i], s2_op).real)
+        table.append({"level": i, "energy": float(values[i]), "s2": s2_value, "spin": spin_from_s2(s2_value)})
+    return table
+
+
+def lowest_sector_energies(h: np.ndarray, config: ToyConfig) -> dict[str, float]:
+    values, vectors = np.linalg.eigh(h)
+    order = np.argsort(values.real)
+    values = values[order].real
+    vectors = vectors[:, order]
+    s2_op = total_spin_squared_operator(config)
+    lowest_singlet = float("nan")
+    lowest_triplet = float("nan")
+    for i, value in enumerate(values):
+        spin = spin_from_s2(float(expectation(vectors[:, i], s2_op).real))
+        if np.isnan(lowest_singlet) and abs(spin - 0.0) < 0.35:
+            lowest_singlet = float(value)
+        if np.isnan(lowest_triplet) and abs(spin - 1.0) < 0.35:
+            lowest_triplet = float(value)
+        if not np.isnan(lowest_singlet) and not np.isnan(lowest_triplet):
+            break
+    return {
+        "lowest_singlet_e": lowest_singlet,
+        "lowest_triplet_e": lowest_triplet,
+        "singlet_triplet_gap": lowest_triplet - lowest_singlet,
+    }

--- a/SU2DetectorResponseToy/src/eec_toy/operators.py
+++ b/SU2DetectorResponseToy/src/eec_toy/operators.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from functools import reduce
+from typing import Iterable
+
+import numpy as np
+
+I2 = np.eye(2, dtype=complex)
+X = np.array([[0, 1], [1, 0]], dtype=complex)
+Y = np.array([[0, -1j], [1j, 0]], dtype=complex)
+Z = np.array([[1, 0], [0, -1]], dtype=complex)
+
+PAULI = {"I": I2, "X": X, "Y": Y, "Z": Z}
+
+
+def kron_all(mats: Iterable[np.ndarray]) -> np.ndarray:
+    return reduce(np.kron, mats)
+
+
+def site_operator(num_qubits: int, site: int, op: np.ndarray) -> np.ndarray:
+    mats = [I2] * num_qubits
+    mats[site] = op
+    return kron_all(mats)
+
+
+def pair_operator(num_qubits: int, left: int, left_op: np.ndarray, right: int, right_op: np.ndarray) -> np.ndarray:
+    mats = [I2] * num_qubits
+    mats[left] = left_op
+    mats[right] = right_op
+    return kron_all(mats)
+
+
+def expectation(state: np.ndarray, operator: np.ndarray) -> complex:
+    return np.vdot(state, operator @ state)
+
+
+def normalize(state: np.ndarray) -> np.ndarray:
+    norm = np.linalg.norm(state)
+    if norm == 0:
+        raise ValueError("不能归一化零态")
+    return state / norm
+
+
+def pauli_rotation_state(state: np.ndarray, pauli_matrix: np.ndarray, theta: float) -> np.ndarray:
+    dim = pauli_matrix.shape[0]
+    return np.cos(theta) * state - 1j * np.sin(theta) * (pauli_matrix @ state)

--- a/SU2DetectorResponseToy/src/eec_toy/qasm_export.py
+++ b/SU2DetectorResponseToy/src/eec_toy/qasm_export.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+
+def singlet_pair_state_prep_qasm(num_qubits: int, measure: bool = True) -> str:
+    if num_qubits % 2 != 0:
+        raise ValueError("SU(2) singlet-pair ansatz 需要偶数 qubit")
+
+    lines = [
+        "OPENQASM 2.0;",
+        'include "qelib1.inc";',
+        f"qreg q[{num_qubits}];",
+        f"creg c[{num_qubits}];",
+    ]
+    for left in range(0, num_qubits, 2):
+        right = left + 1
+        lines.append(f"x q[{right}];")
+        lines.append(f"h q[{left}];")
+        lines.append(f"cx q[{left}],q[{right}];")
+        lines.append(f"z q[{left}];")
+    if measure:
+        for q in range(num_qubits):
+            lines.append(f"measure q[{q}] -> c[{q}];")
+    return "\n".join(lines) + "\n"
+
+
+def su2_color_quench_probe_qasm(num_qubits: int) -> str:
+    if num_qubits % 2 != 0:
+        raise ValueError("SU(2) quench probe ansatz 需要偶数 qubit")
+
+    lines = singlet_pair_state_prep_qasm(num_qubits, measure=False).splitlines()
+    center_left = num_qubits // 2 - 1
+    center_right = num_qubits // 2
+    lines.append(f"cx q[{center_left}],q[{center_right}];")
+    lines.append(f"rz(0.35) q[{center_right}];")
+    lines.append(f"cx q[{center_left}],q[{center_right}];")
+    for q in range(num_qubits):
+        lines.append(f"measure q[{q}] -> c[{q}];")
+    return "\n".join(lines) + "\n"

--- a/SU2DetectorResponseToy/src/eec_toy/scan.py
+++ b/SU2DetectorResponseToy/src/eec_toy/scan.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Iterable
+
+from .model import (
+    ToyConfig,
+    central_quench,
+    connected_detector_correlation,
+    energy,
+    ground_state,
+    hamiltonian,
+    lowest_sector_energies,
+    spectral_weights,
+    spectrum_spin_table,
+    spin_from_s2,
+    total_spin_expectation,
+)
+
+
+def scan_parameter_grid(config: ToyConfig, delta_values: Iterable[float], quench_theta: float = 0.35, levels: int = 8) -> list[dict[str, float | int | list[float]]]:
+    rows = []
+    states = []
+    for delta in delta_values:
+        h = hamiltonian(config, float(delta))
+        spectrum, psi0 = ground_state(h)
+        psiq = central_quench(psi0, config, quench_theta)
+        kept = min(levels, len(spectrum))
+        spin_table = spectrum_spin_table(h, config, kept)
+        sector = lowest_sector_energies(h, config)
+        s2_ground = total_spin_expectation(psi0, config)
+        states.append(psi0)
+        rows.append(
+            {
+                "num_qubits": config.num_qubits,
+                "delta": float(delta),
+                "e0": float(spectrum[0]),
+                "e1": float(spectrum[1]),
+                "e2": float(spectrum[2]) if kept > 2 else float("nan"),
+                "e3": float(spectrum[3]) if kept > 3 else float("nan"),
+                "ground_s2": s2_ground,
+                "ground_spin": spin_from_s2(s2_ground),
+                "level_spins": [item["spin"] for item in spin_table],
+                "level_s2": [item["s2"] for item in spin_table],
+                "lowest_singlet_e": sector["lowest_singlet_e"],
+                "lowest_triplet_e": sector["lowest_triplet_e"],
+                "singlet_triplet_gap": sector["singlet_triplet_gap"],
+                "detector_color_conn": connected_detector_correlation(psi0, config),
+                "quench_delta_e": energy(psiq, h) - float(spectrum[0]),
+                "quench_low_level_weight": spectral_weights(psiq, h, kept),
+                "fidelity_to_previous": 1.0,
+                "fidelity_loss_to_previous": 0.0,
+                "detector_conn_abs_slope": 0.0,
+            }
+        )
+
+    for i in range(1, len(rows)):
+        fidelity = float(abs(states[i - 1].conjugate() @ states[i]) ** 2)
+        rows[i]["fidelity_to_previous"] = fidelity
+        rows[i]["fidelity_loss_to_previous"] = 1.0 - fidelity
+    _fill_detector_slopes(rows)
+    return rows
+
+
+def _fill_detector_slopes(rows: list[dict[str, float | int | list[float]]]) -> None:
+    if len(rows) < 3:
+        return
+    for i in range(1, len(rows) - 1):
+        ddelta = float(rows[i + 1]["delta"]) - float(rows[i - 1]["delta"])
+        if ddelta == 0:
+            continue
+        rows[i]["detector_conn_abs_slope"] = abs(
+            (float(rows[i + 1]["detector_color_conn"]) - float(rows[i - 1]["detector_color_conn"])) / ddelta
+        )
+
+
+def summarize_scan(config: ToyConfig, rows: list[dict[str, float | int | list[float]]]) -> dict[str, object]:
+    min_sector_gap_row = min(rows, key=lambda item: float(item["singlet_triplet_gap"]))
+    detector_slope_row = max(rows, key=lambda item: float(item["detector_conn_abs_slope"]))
+    fidelity_dip_row = max(rows[1:] or rows, key=lambda item: float(item["fidelity_loss_to_previous"]))
+    max_quench_row = max(rows, key=lambda item: float(item["quench_delta_e"]))
+    return {
+        "config": asdict(config),
+        "minimum_singlet_triplet_gap": {
+            "delta": min_sector_gap_row["delta"],
+            "singlet_triplet_gap": min_sector_gap_row["singlet_triplet_gap"],
+            "lowest_singlet_e": min_sector_gap_row["lowest_singlet_e"],
+            "lowest_triplet_e": min_sector_gap_row["lowest_triplet_e"],
+        },
+        "crossover_by_detector_slope": {
+            "delta": detector_slope_row["delta"],
+            "detector_color_conn": detector_slope_row["detector_color_conn"],
+            "detector_conn_abs_slope": detector_slope_row["detector_conn_abs_slope"],
+            "singlet_triplet_gap": detector_slope_row["singlet_triplet_gap"],
+        },
+        "crossover_by_fidelity_dip": {
+            "delta": fidelity_dip_row["delta"],
+            "fidelity_to_previous": fidelity_dip_row["fidelity_to_previous"],
+            "fidelity_loss_to_previous": fidelity_dip_row["fidelity_loss_to_previous"],
+            "singlet_triplet_gap": fidelity_dip_row["singlet_triplet_gap"],
+        },
+        "largest_singlet_quench_response": {
+            "delta": max_quench_row["delta"],
+            "quench_delta_e": max_quench_row["quench_delta_e"],
+            "detector_color_conn": max_quench_row["detector_color_conn"],
+        },
+        "interpretation": "SU(2)-symmetric finite-chain demo: singlet/triplet sector energies, detector color correlation, fidelity loss, and a central color-singlet quench show a small-system precursor of spectral rearrangement without claiming a thermodynamic phase transition",
+    }

--- a/SU2DetectorResponseToy/tests/test_eec_toy.py
+++ b/SU2DetectorResponseToy/tests/test_eec_toy.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from eec_toy.model import ToyConfig, central_quench, ground_state, hamiltonian, total_spin_expectation
+from eec_toy.qasm_export import singlet_pair_state_prep_qasm
+from eec_toy.scan import scan_parameter_grid, summarize_scan
+
+
+def test_su2_hamiltonian_is_hermitian() -> None:
+    config = ToyConfig(num_qubits=6)
+    h = hamiltonian(config, dimer_delta=0.2)
+    assert np.allclose(h, h.conjugate().T)
+
+
+def test_ground_state_is_normalized_and_near_singlet() -> None:
+    config = ToyConfig(num_qubits=6)
+    values, psi0 = ground_state(hamiltonian(config, dimer_delta=0.2))
+    assert values[1] >= values[0]
+    assert np.isclose(np.linalg.norm(psi0), 1.0)
+    assert total_spin_expectation(psi0, config) < 1e-8
+
+
+def test_color_singlet_quench_preserves_norm() -> None:
+    config = ToyConfig(num_qubits=6)
+    _, psi0 = ground_state(hamiltonian(config, dimer_delta=0.2))
+    psiq = central_quench(psi0, config, theta=0.35)
+    assert np.isclose(np.linalg.norm(psiq), 1.0)
+
+
+def test_scan_summary_has_su2_sector_diagnostics() -> None:
+    config = ToyConfig(num_qubits=6)
+    rows = scan_parameter_grid(config, [-0.4, 0.0, 0.4], quench_theta=0.2)
+    summary = summarize_scan(config, rows)
+    assert "minimum_singlet_triplet_gap" in summary
+    assert "crossover_by_detector_slope" in summary
+    assert summary["minimum_singlet_triplet_gap"]["singlet_triplet_gap"] >= 0.0
+
+
+def test_singlet_pair_qasm_shape() -> None:
+    qasm = singlet_pair_state_prep_qasm(4)
+    assert "OPENQASM 2.0" in qasm
+    assert "cx q[0],q[1];" in qasm
+    assert "cx q[2],q[3];" in qasm


### PR DESCRIPTION
## 概要

本 PR 新增一个自包含的 SU(2)-对称量子模拟教程示例，并提供 pyQPanda CPUQVM 线路构造示例。

数值部分通过小规模 color-chain toy Hamiltonian 的精确对角化生成参考观测量；pyQPanda 示例使用 CPUQVM 构造并运行对应的 singlet 态制备与局域 probe 线路；OpenQASM 文件提供可迁移线路原型。该示例适合作为量子多体模拟、SU(2) sector 诊断和 pyQPanda CPUQVM 入门教程。

## 主要内容

- `Tutorials/SU2DetectorResponseToy/README.md`：教程入口与运行说明。
- `DERIVATION.md`：说明 SU(2)-scalar interaction、sector 诊断、局域 quench 与 connected correlation。
- `run_tutorial.py`：运行 4 到 8 个 qubit 的小规模有限尺寸扫描。
- `make_tutorial_plots.py`：根据扫描结果生成诊断图表。
- `pyqpanda_cpuqvm_example.py`：pyQPanda CPUQVM 线路原型，可运行并输出 bitstring counts。
- README 中补充赛事指定工具使用说明，以及数值诊断量、输出文件与 pyQPanda / OpenQASM 线路的对应关系。
- `src/eec_toy/`：教程使用的可复用 toy-model 工具。
- `tests/test_eec_toy.py`：基础正确性检查。

## 教程输出

教程会输出以下诊断量：

- singlet/triplet sector energies。
- singlet-triplet gap。
- ground-state fidelity loss。
- central color-singlet quench energy injection。
- left-right detector connected color correlation。
- 态制备与局域 probe 线路的 OpenQASM 原型。

## 运行方式

```bash
python Tutorials/SU2DetectorResponseToy/run_tutorial.py --num-qubits 6 --points 17
python Tutorials/SU2DetectorResponseToy/make_tutorial_plots.py
```

可选 pyQPanda CPUQVM 示例：

```bash
python Tutorials/SU2DetectorResponseToy/pyqpanda_cpuqvm_example.py --num-qubits 6 --shots 1000
```

`pyqpanda` 只用于 CPUQVM 示例。数值教程部分只需要 NumPy 与 Matplotlib 即可运行。

## 测试方式

- 编译检查所有 Python 脚本。
- 运行 6-qubit、17 个参数点的 tutorial scan。
- 根据 `summary.json` 生成图表。
- 运行 pyQPanda CPUQVM 示例，验证 singlet-pair preparation 与 local probe circuit 可执行，并输出 bitstring counts。
- 运行基础测试，检查 Hermiticity、sector diagnostics、quench normalization、scan summary fields 和 QASM circuit shape。

## 说明

生成的输出目录与 Python 缓存文件已通过 `.gitignore` 排除。