### PR TITLE
【代码贡献】Add missing pandas and scikit-learn to requirements.txt

### DIFF
--- a/pyqpanda-algorithm/requirements.txt
+++ b/pyqpanda-algorithm/requirements.txt
@@ -3,6 +3,8 @@ matplotlib>=3.3
 pydot
 scipy
 sympy
+pandas
+scikit-learn
 mypy>=1.14
 requests
 pycryptodome


### PR DESCRIPTION
requirements.txt is missing pandas and scikit-learn even though the package
imports them, so a fresh install + `import pyqpanda_alg` fails:

    ModuleNotFoundError: No module named 'pandas'

pandas is imported by QSVD, and sklearn (scikit-learn) by QSVM, QSVR and
QKmeans. Added both to requirements.txt. Checked by installing into a clean
virtualenv from requirements.txt only and importing pyqpanda_alg plus the
affected modules.

Relates to #13.
