### PR TITLE
【代码贡献】新增VQE变分量子本征求解器

### DIFF
--- a/pyqpanda-algorithm/test/10-VQE/demo01-VQE-vqe-vqe_solver.ipynb
+++ b/pyqpanda-algorithm/test/10-VQE/demo01-VQE-vqe-vqe_solver.ipynb
@@ -3,34 +3,108 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1c2b8dca",
    "metadata": {},
    "outputs": [],
    "source": [
     "import sys\n",
-    "sys.path.append('/home/bylz/wh/GitData/pyqpanda-algorithm/pyqpanda-algorithm')"
+    "from pathlib import Path\n",
+    "sys.path.append(str(Path.cwd().parent.parent))\n",
+    "\n",
+    "import numpy as np\n",
+    "from pyqpanda3.hamiltonian import PauliOperator\n",
+    "from pyqpanda_alg.VQE import VQE"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# VQE Demo 1: Single-Qubit Solver\n",
+    "\n",
+    "This notebook demonstrates the VQE algorithm on a simple single-qubit\n",
+    "Hamiltonian:\n",
+    "\n",
+    "$$H = -Z = \\begin{pmatrix}-1 & 0 \\\\ 0 & 1\\end{pmatrix}$$\n",
+    "\n",
+    "The ground state is $|0\\rangle$ with energy $-1$.\n",
+    "The excited state is $|1\\rangle$ with energy $+1$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define the Hamiltonian (negative sign so |0⟩ is the ground state)\n",
+    "H = PauliOperator({\"Z0\": -1.0})\n",
+    "print(f\"Hamiltonian: {H}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create VQE solver with hardware-efficient ansatz (depth=2)\n",
+    "vqe = VQE(H, n_qubits=1, ansatz_depth=2)\n",
+    "print(f\"Number of qubits: {vqe.n_qubits}\")\n",
+    "print(f\"Number of parameters: {vqe.n_params}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check energy at identity parameters: |0⟩ → ⟨0|-Z|0⟩ = -1\n",
+    "energy_initial = vqe.calculate_energy([0.0, 0.0, 0.0, 0.0])\n",
+    "print(f\"Energy at [0,0,0,0]: {energy_initial:.6f} (expect -1.0)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run VQE optimization\n",
+    "ground_energy = vqe.run(optimizer='SLSQP', maxiter=100)\n",
+    "print(f\"\\n=== Results ===\")\n",
+    "print(f\"Ground-state energy: {ground_energy:.6f}\")\n",
+    "print(f\"Target (exact):      -1.0\")\n",
+    "print(f\"Optimal parameters:  {np.round(vqe.optimal_params, 4)}\")\n",
+    "print(f\"Iterations:          {len(vqe.energy_history)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot convergence\n",
+    "import matplotlib.pyplot as plt\n",
+    "plt.plot(vqe.energy_history, '-o', markersize=3)\n",
+    "plt.axhline(y=-1.0, color='r', linestyle='--', label='Target (-1.0)')\n",
+    "plt.xlabel('Optimizer iteration')\n",
+    "plt.ylabel('Energy')\n",
+    "plt.title('VQE Convergence (1-qubit, H = -Z)')\n",
+    "plt.legend()\n",
+    "plt.grid(True)\n",
+    "plt.show()"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "py310_wh",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.14"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 5
+ "nbformat_minor": 4
 }

--- a/pyqpanda-algorithm/test/10-VQE/demo02-VQE-vqe-hardware_efficient_circuit.ipynb
+++ b/pyqpanda-algorithm/test/10-VQE/demo02-VQE-vqe-hardware_efficient_circuit.ipynb
@@ -3,34 +3,133 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1c2b8dca",
    "metadata": {},
    "outputs": [],
    "source": [
     "import sys\n",
-    "sys.path.append('/home/bylz/wh/GitData/pyqpanda-algorithm/pyqpanda-algorithm')"
+    "from pathlib import Path\n",
+    "sys.path.append(str(Path.cwd().parent.parent))\n",
+    "\n",
+    "import numpy as np\n",
+    "from pyqpanda3.hamiltonian import PauliOperator\n",
+    "from pyqpanda3.core import QProg\n",
+    "from pyqpanda_alg.VQE import VQE\n",
+    "from pyqpanda_alg.VQE.vqe import hardware_efficient_circuit"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# VQE Demo 2: Hardware-Efficient Ansatz\n",
+    "\n",
+    "This notebook demonstrates the hardware-efficient ansatz and solves\n",
+    "a two-qubit Hamiltonian:\n",
+    "\n",
+    "$$H = -Z_0 - Z_1 + 0.5 \\cdot Z_0 Z_1$$\n",
+    "\n",
+    "Ground state $|00\\rangle$:\n",
+    "\n",
+    "$$E = \\langle 00|H|00\\rangle = (-1) + (-1) + 0.5 = -1.5$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visualize the hardware-efficient ansatz circuit (depth=2, 3 qubits)\n",
+    "n_qubits = 3\n",
+    "q = QProg(n_qubits).qubits()\n",
+    "params = [0.1] * (2 * n_qubits * 2)\n",
+    "cir = hardware_efficient_circuit(q, params, depth=2)\n",
+    "print(cir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Two-qubit Hamiltonian: negative Z terms so |00⟩ is the ground state\n",
+    "H = (PauliOperator({\"Z0\": -1.0})\n",
+    "     + PauliOperator({\"Z1\": -1.0})\n",
+    "     + PauliOperator({\"Z0 Z1\": 0.5}))\n",
+    "print(f\"Hamiltonian: {H}\")\n",
+    "print(f\"Exact ground-state energy: -1.5 (state |00⟩)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create VQE solver with depth=2 ansatz\n",
+    "vqe = VQE(H, ansatz_depth=2)\n",
+    "print(f\"Number of qubits: {vqe.n_qubits}\")\n",
+    "print(f\"Number of parameters: {vqe.n_params}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run VQE optimization with SLSQP\n",
+    "print(\"Running VQE optimization (SLSQP)...\")\n",
+    "ground_energy = vqe.run(optimizer='SLSQP', maxiter=200)\n",
+    "print(f\"\\n=== Results ===\")\n",
+    "print(f\"Ground-state energy: {ground_energy:.6f}\")\n",
+    "print(f\"Exact:               -1.500000\")\n",
+    "print(f\"Error:               {abs(ground_energy + 1.5):.2e}\")\n",
+    "print(f\"Optimal params: {np.round(vqe.optimal_params, 4)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Compare SLSQP vs SPSA convergence\n",
+    "vqe_spsa = VQE(H, ansatz_depth=2)\n",
+    "energy_spsa = vqe_spsa.run(optimizer='SPSA', maxiter=200)\n",
+    "print(f\"SLSQP energy: {ground_energy:.6f}\")\n",
+    "print(f\"SPSA  energy: {energy_spsa:.6f}\")\n",
+    "print(f\"Exact:        -1.500000\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot convergence comparison\n",
+    "import matplotlib.pyplot as plt\n",
+    "plt.plot(vqe.energy_history, '-o', markersize=3, alpha=0.7, label='SLSQP')\n",
+    "plt.plot(vqe_spsa.energy_history, '-s', markersize=3, alpha=0.7, label='SPSA')\n",
+    "plt.axhline(y=-1.5, color='r', linestyle='--', label='Exact (-1.5)')\n",
+    "plt.xlabel('Optimizer iteration')\n",
+    "plt.ylabel('Energy')\n",
+    "plt.title('VQE Convergence: SLSQP vs SPSA')\n",
+    "plt.legend()\n",
+    "plt.grid(True)\n",
+    "plt.show()"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "py310_wh",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.14"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 5
+ "nbformat_minor": 4
 }

--- a/pyqpanda_alg/VQE/__init__.py
+++ b/pyqpanda_alg/VQE/__init__.py
@@ -1,0 +1,17 @@
+'''
+Variational Quantum Eigensolver (VQE)
+
+VQE is a hybrid quantum-classical algorithm designed to find the
+ground-state energy of a given Hamiltonian. It uses a parameterized
+quantum circuit (ansatz) to prepare trial states, measures the
+expectation value of the Hamiltonian, and iteratively improves the
+parameters via a classical optimizer.
+
+The VQE module provides:
+
+    - VQE : Main class for running the VQE algorithm.
+'''
+
+from .vqe import VQE
+
+__all__ = ['VQE']

--- a/pyqpanda_alg/VQE/vqe.py
+++ b/pyqpanda_alg/VQE/vqe.py
@@ -1,0 +1,434 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pyqpanda3.core import CPUQVM, QCircuit, QProg, RY, RZ, CNOT, H, RX, CZ, measure
+from pyqpanda3.hamiltonian import PauliOperator, Hamiltonian
+import numpy as np
+from scipy.optimize import minimize
+
+from ..QAOA import spsa
+from ..plugin import *
+
+
+# ─────────────────────────────────────────────────────────────
+#  Built-in Ansatz Circuits
+# ─────────────────────────────────────────────────────────────
+
+def hardware_efficient_circuit(qlist, params, depth=2, entangle='linear'):
+    """
+    Build a hardware-efficient ansatz circuit.
+
+    Each layer consists of:
+        1. RY and RZ rotations on every qubit
+        2. CNOT entangling gates between adjacent qubits
+
+    Parameters
+    ----------
+    qlist : list
+        Qubit list.
+    params : array-like
+        Flattened parameter vector with length ``2 * n_qubits * depth``.
+    depth : int, optional
+        Number of variational layers (default 2).
+    entangle : str, optional
+        Entangling scheme: ``'linear'`` (default) or ``'full'``.
+
+    Returns
+    -------
+    QCircuit
+        Hardware-efficient parameterized circuit.
+
+    Examples
+    --------
+    >>> from pyqpanda_alg.VQE.vqe import hardware_efficient_circuit
+    >>> from pyqpanda3.core import QProg
+    >>> q = QProg(3).qubits()
+    >>> params = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2]
+    >>> cir = hardware_efficient_circuit(q, params, depth=2)
+    """
+    n = len(qlist)
+    circuit = QCircuit()
+    param_idx = 0
+
+    for _ in range(depth):
+        # Rotation layer: RY + RZ on each qubit
+        for j in range(n):
+            circuit << RY(qlist[j], params[param_idx])
+            param_idx += 1
+        for j in range(n):
+            circuit << RZ(qlist[j], params[param_idx])
+            param_idx += 1
+
+        # Entanglement layer
+        if entangle == 'linear':
+            for j in range(n - 1):
+                circuit << CNOT(qlist[j], qlist[j + 1])
+            # Close the ring
+            if n > 2:
+                circuit << CNOT(qlist[-1], qlist[0])
+        elif entangle == 'full':
+            for j in range(n):
+                for k in range(j + 1, n):
+                    circuit << CNOT(qlist[j], qlist[k])
+        else:
+            raise ValueError(f"Unknown entangle scheme: {entangle}")
+
+    return circuit
+
+
+# ─────────────────────────────────────────────────────────────
+#  VQE Main Class
+# ─────────────────────────────────────────────────────────────
+
+class VQE:
+    """
+    Variational Quantum Eigensolver (VQE).
+
+    This class implements a hybrid quantum-classical algorithm to find
+    the ground-state energy of a given Hamiltonian.  It uses a
+    parameterized quantum circuit (ansatz) to prepare trial states,
+    measures the expectation value of the Hamiltonian, and iteratively
+    improves the parameters via a classical optimizer.
+
+    Parameters
+    ----------
+    hamiltonian : PauliOperator or Hamiltonian
+        The Hamiltonian whose ground-state energy is sought.
+    n_qubits : int, optional
+        Number of qubits.  If not given it is inferred from the
+        Hamiltonian.
+    ansatz_circuit : callable, optional
+        Function ``f(qlist, params) -> QCircuit`` that builds the
+        parameterized trial-state circuit.  Defaults to
+        :func:`hardware_efficient_circuit` with depth=2.
+    ansatz_depth : int, optional
+        Depth (number of layers) for the built-in hardware-efficient
+        ansatz.  Ignored when a custom ``ansatz_circuit`` is supplied.
+        Default 2.
+
+    Attributes
+    ----------
+    n_qubits : int
+        Number of qubits.
+    n_params : int
+        Number of variational parameters.
+    energy_history : list[float]
+        Energy value at each optimizer iteration.
+    optimal_params : ndarray
+        Best parameters found by the optimizer.
+
+    Methods
+    -------
+    run(optimizer='SLSQP', maxiter=200, initial_params=None, shots=-1, **opt_kwargs)
+        Run the VQE optimization and return the ground-state energy.
+
+    calculate_energy(params, shots=-1)
+        Run the ansatz circuit with given parameters and compute
+        the expectation value ⟨ψ|H|ψ⟩.
+
+    References
+    ----------
+    .. [1] Peruzzo A, McClean J, Shadbolt P, et al.
+           A variational eigenvalue solver on a photonic quantum processor.
+           Nature Communications, 2014, 5: 4213.
+           https://doi.org/10.1038/ncomms5213
+
+    Examples
+    --------
+    Construct a simple Hamiltonian and find its ground-state energy:
+
+    >>> from pyqpanda3.hamiltonian import PauliOperator
+    >>> from pyqpanda_alg.VQE import VQE
+    >>> import numpy as np
+    >>> H = (PauliOperator({"Z0": 1.0})
+    ...      + PauliOperator({"X0": 0.5}))
+    >>> solver = VQE(H, n_qubits=1, ansatz_depth=2)
+    >>> energy = solver.run(optimizer='SLSQP', maxiter=100)
+    >>> print(f"Ground-state energy: {energy:.6f}")
+    """
+
+    # ── constructor ──────────────────────────────────────────
+
+    def __init__(self,
+                 hamiltonian,
+                 n_qubits=None,
+                 ansatz_circuit=None,
+                 ansatz_depth=2):
+        # --- Hamiltonian ---
+        if isinstance(hamiltonian, Hamiltonian):
+            self._operator = hamiltonian.pauli_operator()
+        elif isinstance(hamiltonian, PauliOperator):
+            self._operator = hamiltonian
+        else:
+            raise TypeError(
+                "hamiltonian must be a PauliOperator or Hamiltonian, "
+                f"got {type(hamiltonian)}"
+            )
+
+        # --- Number of qubits ---
+        if n_qubits is None:
+            qubits = set()
+            for term in self._operator.terms():
+                for p in term.paulis():
+                    if p.is_Z() or p.is_X() or p.is_Y():
+                        qubits.add(p.qbit())
+            self.n_qubits = max(qubits) + 1 if qubits else 1
+        else:
+            self.n_qubits = n_qubits
+
+        # --- Ansatz ---
+        if ansatz_circuit is not None:
+            self._ansatz = ansatz_circuit
+            self.ansatz_depth = None  # user-defined
+        else:
+            self._ansatz = lambda q, p: hardware_efficient_circuit(
+                q, p, depth=ansatz_depth
+            )
+            self.ansatz_depth = ansatz_depth
+
+        # Number of parameters: 2 * n_qubits * depth
+        if self.ansatz_depth is not None:
+            self.n_params = 2 * self.n_qubits * self.ansatz_depth
+        else:
+            self.n_params = None  # will be inferred later
+
+        # --- State ---
+        self.energy_history = []
+        self.optimal_params = None
+        self._circuit_iter = 0
+
+    # ── core: run circuit → energy ───────────────────────────
+
+    def calculate_energy(self, params, shots=-1):
+        """
+        Run the ansatz with *params* and return ⟨ψ(θ)|H|ψ(θ)⟩.
+
+        Parameters
+        ----------
+        params : array-like
+            Variational parameters.
+        shots : int, optional
+            Number of measurement shots.  ``-1`` uses the state-vector
+            simulator (theoretical / infinite-shots result).  Default
+            is ``-1``.
+
+        Returns
+        -------
+        float
+            Expectation value of the Hamiltonian.
+        """
+        qvm = CPUQVM()
+        prog = QProg(self.n_qubits)
+        qlist = prog.qubits()
+
+        # Build and insert ansatz
+        if self.n_params is None:
+            # First call: infer parameter count from the user circuit
+            self.n_params = len(params)
+        cir = self._ansatz(qlist, params)
+        prog << cir
+
+        # --- State-vector (theoretical) mode ---
+        if shots == -1:
+            qvm.run(prog, shots=1)
+            prob_dict = qvm.result().get_prob_dict(qlist)
+            prob_dict = parse_quantum_result_dict(
+                prob_dict, qlist, select_max=-1
+            )
+
+            energy = 0.0
+            for bitstring, prob in prob_dict.items():
+                # bitstring is e.g. '010'  (lowest qubit on the right)
+                config = [int(c) for c in bitstring[::-1]]
+                e_state = self._compute_energy_of_config(config)
+                energy += prob * e_state
+            return energy
+
+        # --- Sampling mode ---
+        elif shots > 0:
+            prog << measure_all(qlist, qlist)
+            qvm.run(prog, shots=shots)
+            counts = qvm.result().get_counts()
+
+            energy = 0.0
+            total = sum(counts.values())
+            for bitstring, cnt in counts.items():
+                config = [int(c) for c in bitstring[::-1]]
+                e_state = self._compute_energy_of_config(config)
+                energy += (cnt / total) * e_state
+            return energy
+
+        else:
+            raise ValueError(f"Invalid shots number: {shots}")
+
+    def _compute_energy_of_config(self, config):
+        """
+        Compute the energy of a single computational-basis
+        configuration.
+
+        Parameters
+        ----------
+        config : list[int]
+            Binary list, e.g. ``[1, 0, 1]`` for q0=1, q1=0, q2=1.
+
+        Returns
+        -------
+        float
+        """
+        energy = 0.0
+        for term in self._operator.terms():
+            coef = term.coef()
+            coef_real = coef.real if isinstance(coef, complex) else coef
+
+            term_contrib = coef_real
+            for pauli in term.paulis():
+                idx = pauli.qbit()
+                p_char = pauli.pauli_char()
+
+                if idx >= len(config):
+                    # qubit index outside config — treat as 0
+                    continue
+
+                if p_char == 'I':
+                    continue
+                elif p_char == 'Z':
+                    # Z|b⟩ = (-1)^b |b⟩
+                    if config[idx] == 1:
+                        term_contrib *= -1
+                elif p_char == 'X':
+                    # X|0⟩ = |1⟩, X|1⟩ = |0⟩ — off-diagonal,
+                    # expectation is zero for computational basis
+                    term_contrib = 0
+                    break
+                elif p_char == 'Y':
+                    # Y|0⟩ = i|1⟩, Y|1⟩ = -i|0⟩ — off-diagonal
+                    term_contrib = 0
+                    break
+                else:
+                    term_contrib = 0
+                    break
+
+            energy += term_contrib
+
+        return energy
+
+    # ── loss function for the optimizer ──────────────────────
+
+    def _loss_function(self, params, shots=-1):
+        """
+        Loss function called by the classical optimizer.
+
+        Parameters
+        ----------
+        params : ndarray
+            Current parameter vector.
+        shots : int
+
+        Returns
+        -------
+        float
+            Energy expectation value.
+        """
+        energy = self.calculate_energy(params, shots=shots)
+        self.energy_history.append(energy)
+        self._circuit_iter += 1
+        return energy
+
+    # ── main entry point ─────────────────────────────────────
+
+    def run(self,
+            optimizer='SLSQP',
+            maxiter=200,
+            initial_params=None,
+            shots=-1,
+            **opt_kwargs):
+        """
+        Run the VQE optimization.
+
+        Parameters
+        ----------
+        optimizer : str, optional
+            Classical optimizer.  ``'SLSQP'`` (default), ``'SPSA'``,
+            ``'COBYLA'``, or any method accepted by
+            :func:`scipy.optimize.minimize`.
+        maxiter : int, optional
+            Maximum number of optimizer iterations (default 200).
+        initial_params : ndarray, optional
+            Initial parameter vector.  If not given, random values
+            in ``[0, 2π)`` are used.
+        shots : int, optional
+            Measurement shots.  ``-1`` uses state-vector simulation
+            (default).
+        **opt_kwargs
+            Additional keyword arguments passed to the optimizer.
+
+        Returns
+        -------
+        float
+            Ground-state energy estimate.
+
+        Examples
+        --------
+        >>> from pyqpanda3.hamiltonian import PauliOperator
+        >>> from pyqpanda_alg.VQE import VQE
+        >>> H = PauliOperator({"Z0": 1.0}) + PauliOperator({"Z1": 1.0})
+        >>> v = VQE(H, n_qubits=2, ansatz_depth=1)
+        >>> e = v.run(optimizer='SLSQP', maxiter=100)
+        >>> print(e)
+        """
+        # --- Initial parameters ---
+        if initial_params is None:
+            if self.n_params is None:
+                raise ValueError(
+                    "n_params is unknown; please provide initial_params "
+                    "or use the built-in ansatz."
+                )
+            np.random.seed(42)
+            initial_params = np.random.random(self.n_params) * 2 * np.pi
+
+        initial_params = np.asarray(initial_params, dtype=float)
+
+        if self.n_params is None:
+            self.n_params = len(initial_params)
+
+        # --- Reset state ---
+        self.energy_history = []
+        self._circuit_iter = 0
+
+        # --- Set default options ---
+        if 'options' not in opt_kwargs:
+            opt_kwargs['options'] = {'maxiter': maxiter}
+        else:
+            opt_kwargs['options'].setdefault('maxiter', maxiter)
+
+        # --- Optimize ---
+        if optimizer.upper() == 'SPSA':
+            final = spsa.spsa_minimize(
+                lambda p: self._loss_function(p, shots=shots),
+                initial_params,
+                **opt_kwargs
+            )
+            self.optimal_params = final
+        else:
+            result = minimize(
+                lambda p: self._loss_function(p, shots=shots),
+                initial_params,
+                method=optimizer,
+                **opt_kwargs
+            )
+            self.optimal_params = result.x
+
+        # --- Final energy ---
+        final_energy = self.calculate_energy(self.optimal_params, shots=shots)
+        self.energy_history.append(final_energy)
+
+        return final_energy

--- a/pyqpanda_alg/__init__.py
+++ b/pyqpanda_alg/__init__.py
@@ -1,0 +1,54 @@
+'''
+A Quantum Optimization Algorithm Set, based on pyqpanda.
+
+The **QMengJi** is a collection of fundamental quantum optimization algorithms and
+functions that are commonly used in developer's optimization problems.
+
+The QMengJi provides standardized set of tools and building blocks for writing quantum programs.
+
+Some key functions included in the QMengJi are:
+
+Quantum Approximate Optimization Algorithm : This is a quantum algorithm that can be used to search the lowest energy
+eigenstate of a Hamiltonian. It is considered to be one of the candidate algorithms for quantum advantage.
+Developer can construct object by QAOA(problem, arg1, arg2…) and directly call QAOA.run(args) to optimize their
+user-defined problem.
+
+Overall, the QMengJi provides a standardized set of tools for developers, allowing them to optimize functions with
+binary variables, such as combinatorial optimization problems, that may have many practical implications.
+Developers can use quantum algorithms directly to obtain results without knowing anything about quantum computing, or
+build their own suitable quantum circuits to obtain more customized results according to their requirements.It is an 
+important resource for solving optimization problems and advancing research on quantum optimization algorithms.
+
+'''
+'''
+pyqpanda-algorithm Python\n
+Copyright (C) Origin Quantum 2017-2023\n
+Licensed Under Apache Licence 2.0
+'''
+
+import warnings
+warnings.filterwarnings("ignore", category=SyntaxWarning)
+
+from . import QAOA
+from . import VQE
+# from . import HHL
+# from . import QAOA
+from . import QARM
+from . import QKmeans
+# from . import QLuoShu
+from . import QPCA
+# from . import QSolver
+from . import QSVM
+# from . import extensions
+# import warnings
+
+#QFinance
+from . import QUBO
+from . import QCmp
+from . import QAE
+from . import QSVD
+from . import QSVR
+from . import Grover
+from . import QmRMR
+from . import QSEncode
+

--- a/test/VQE/Test_vqe.py
+++ b/test/VQE/Test_vqe.py
@@ -1,0 +1,99 @@
+import pytest
+import sys
+from pathlib import Path
+
+# Add project root to path (works from any working directory)
+_project_root = Path(__file__).resolve().parent.parent.parent
+_pkg_root = _project_root / "pyqpanda-algorithm"
+sys.path.insert(0, str(_project_root))
+sys.path.insert(0, str(_pkg_root))
+
+import numpy as np
+from pyqpanda3.hamiltonian import PauliOperator
+from pyqpanda_alg.VQE import VQE
+
+
+class TestVQE:
+    """Tests for the VQE algorithm."""
+
+    def test_initialization(self):
+        """Test that VQE object can be created."""
+        H = PauliOperator({"Z0": 1.0})
+        v = VQE(H, n_qubits=1, ansatz_depth=1)
+        assert v.n_qubits == 1
+        assert v.n_params == 2  # 2 * 1 * 1
+
+    def test_initialization_multiqubit(self):
+        """Test initialization with multi-qubit Hamiltonian."""
+        H = (PauliOperator({"Z0": 1.0})
+             + PauliOperator({"Z1": 1.0})
+             + PauliOperator({"Z0 Z1": 0.5}))
+        v = VQE(H, ansatz_depth=2)
+        assert v.n_qubits == 2
+        assert v.n_params == 8  # 2 * 2 * 2
+
+    def test_calculate_energy_single_qubit(self):
+        """Test calculate_energy for a single-qubit Hamiltonian."""
+        # H = Z (eigenvalues: |0⟩→+1, |1⟩→-1)
+        H = PauliOperator({"Z0": 1.0})
+        v = VQE(H, n_qubits=1, ansatz_depth=1)
+
+        # params = [0, 0] → RY(0)RZ(0) = Identity → |0⟩ → E = +1
+        energy = v.calculate_energy([0.0, 0.0], shots=-1)
+        assert abs(energy - 1.0) < 1e-10, f"Expected +1.0, got {energy}"
+
+    def test_calculate_energy_two_qubit(self):
+        """Test calculate_energy for a two-qubit Hamiltonian."""
+        # H = Z0 + Z1: |00⟩→+2, |11⟩→-2 (ground)
+        H = PauliOperator({"Z0": 1.0}) + PauliOperator({"Z1": 1.0})
+        v = VQE(H, n_qubits=2, ansatz_depth=1)
+
+        # Identity circuit → |00⟩ → E = +2
+        energy = v.calculate_energy([0.0, 0.0, 0.0, 0.0], shots=-1)
+        assert abs(energy - 2.0) < 1e-10, f"Expected +2.0, got {energy}"
+
+    def test_run_single_qubit(self):
+        """Test that run() converges for a simple Hamiltonian."""
+        # H = Z, ground = |1⟩, energy = -1
+        H = PauliOperator({"Z0": 1.0})
+        v = VQE(H, n_qubits=1, ansatz_depth=2)
+
+        energy = v.run(optimizer='SLSQP', maxiter=100)
+        assert energy < -0.9, f"Energy {energy} not close to ground state -1"
+
+    def test_run_two_qubit(self):
+        """Test that run() converges for a two-qubit Hamiltonian."""
+        # H = Z0 + Z1, ground = |11⟩, energy = -2
+        H = PauliOperator({"Z0": 1.0}) + PauliOperator({"Z1": 1.0})
+        v = VQE(H, n_qubits=2, ansatz_depth=2)
+
+        energy = v.run(optimizer='SLSQP', maxiter=100)
+        assert energy < -1.8, f"Energy {energy} not close to ground state -2"
+
+    def test_energy_history(self):
+        """Test that energy history is recorded."""
+        H = PauliOperator({"Z0": 1.0})
+        v = VQE(H, n_qubits=1, ansatz_depth=1)
+
+        v.run(optimizer='SLSQP', maxiter=50)
+        assert len(v.energy_history) > 0, "Energy history should not be empty"
+        assert len(v.energy_history) > 1, "Should have more than one energy value"
+
+    def test_optimal_params_stored(self):
+        """Test that optimal parameters are stored after run."""
+        H = PauliOperator({"Z0": 1.0})
+        v = VQE(H, n_qubits=1, ansatz_depth=2)
+
+        v.run(optimizer='SLSQP', maxiter=50)
+        assert v.optimal_params is not None
+        assert len(v.optimal_params) == v.n_params
+
+    def test_n_qubits_inferred(self):
+        """Test that n_qubits is correctly inferred from Hamiltonian."""
+        H = PauliOperator({"Z3": 1.0})
+        v = VQE(H, ansatz_depth=1)
+        assert v.n_qubits == 4, f"Expected 4 qubits, got {v.n_qubits}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
## 新增 VQE（变分量子本征求解器）模块

### 新增内容
- `pyqpanda_alg/VQE/vqe.py` — VQE 主类（434行），支持：
  - 硬件高效 Ansatz（RY+RZ 旋转 + CNOT 纠缠层，linear/full 两种模式）
  - 自定义 Ansatz 电路
  - SLSQP / SPSA / COBYLA 等经典优化器
  - Statevector 模式（shots=-1）和采样模式（shots>0）
  - 自动推断量子比特数
- `test/VQE/Test_vqe.py` — 9 个单元测试用例
- `test/10-VQE/demo01-*.ipynb` — 单量子比特 VQE 演示（H = -Z）
- `test/10-VQE/demo02-*.ipynb` — 双量子比特 VQE 演示（SLSQP vs SPSA 收敛对比）

### 使用示例
```python
from pyqpanda3.hamiltonian import PauliOperator
from pyqpanda_alg.VQE import VQE

H = PauliOperator({"Z0": -1.0}) + PauliOperator({"Z1": -1.0})
v = VQE(H, ansatz_depth=2)
energy = v.run(optimizer='SLSQP', maxiter=200)
print(f"Ground-state energy: {energy}")