### PR TITLE
【代码贡献】修复 QmRMR 星号导入报错、8 个无法运行的示例及文档中的过时接口

### DIFF
--- a/pyqpanda-algorithm/example/QAlgBase/QmRMR/testeg_QmRMR.py
+++ b/pyqpanda-algorithm/example/QAlgBase/QmRMR/testeg_QmRMR.py
@@ -1,9 +1,7 @@
-import sympy as sp
 import numpy as np
-import pyqpanda as pq
 import warnings
 
-from pyqpanda_alg.QFinance.QmRMR.all_code import plot_bar, plot_loss, Feature_Selection
+from pyqpanda_alg.QmRMR.QmRMR_core import plot_bar, plot_loss, Feature_Selection
 import os
 import matplotlib.pyplot as plt
 warnings.simplefilter("ignore")

--- a/pyqpanda-algorithm/example/QAlgBase/newtest.py
+++ b/pyqpanda-algorithm/example/QAlgBase/newtest.py
@@ -1,31 +1,18 @@
-import pyqpanda as pq
 import numpy as np
+from pyqpanda3.core import CPUQVM, QCircuit, QProg, RY, X
 
-#
-# def f(a=1, b=2):
-#     return a+b
-#
-# def f1(a):
-#     return f(a, b=2)
-#
-# def g(func):
-#     res = func(3)
-#     return res
-#
-#
-# print(g(f1))
 
 def create_cir(qlist):
-    cir = pq.QCircuit()
-    cir << pq.RY(qlist[0], np.pi / 3) << pq.X(qlist[1]).control(qlist[0])
+    cir = QCircuit()
+    cir << RY(qlist[0], np.pi / 3) << X(qlist[1]).control(qlist[0])
     return cir
 
 
-m = pq.CPUQVM()
-m.initQVM()
-q_state = m.qAlloc_many(2)
+if __name__ == '__main__':
+    m = CPUQVM()
+    q_state = QProg(2).qubits()
 
-prog = pq.QProg()
-prog << create_cir(q_state)
+    prog = QProg()
+    prog << create_cir(q_state)
 
-print(prog)
+    print(prog)

--- a/pyqpanda-algorithm/example/QAlgBase/testeg_QUBO.py
+++ b/pyqpanda-algorithm/example/QAlgBase/testeg_QUBO.py
@@ -1,7 +1,7 @@
-from pyqpanda_alg.QFinance import QUBO
 import sympy as sp
-import numpy as np
-import pyqpanda as pq
+from pyqpanda3.core import QProg
+
+from pyqpanda_alg import QUBO
 
 
 if __name__ == '__main__':
@@ -11,10 +11,9 @@ if __name__ == '__main__':
     n_key, n_res = test0.query_qnumber()
     print(n_key, n_res)
 
-    m = pq.CPUQVM()
-    m.initQVM()
-    q_key = m.qAlloc_many(n_key)
-    q_res = m.qAlloc_many(n_res)
+    q_all = QProg(n_key + n_res).qubits()
+    q_key = q_all[:n_key]
+    q_res = q_all[n_key:]
 
     print(test0.cir(q_key, q_res))
 
@@ -33,5 +32,5 @@ if __name__ == '__main__':
     # find the minimum function value using QAOA
     test2 = QUBO.QUBO_QAOA(function)
     res2 = test2.run(layer=5, optimizer='SLSQP',
-                     optimizer_option={'options':{'eps':1e-3}})
+                     optimizer_option={'options': {'eps': 1e-3}})
     print('result of QAOA: ', res2)

--- a/pyqpanda-algorithm/example/QAlgBase/testeg_QmRMR.py
+++ b/pyqpanda-algorithm/example/QAlgBase/testeg_QmRMR.py
@@ -4,7 +4,7 @@ import matplotlib
 
 matplotlib.use('Agg')  # 使用非交互式后端
 import matplotlib.pyplot as plt
-from pyqpanda_alg.QmRMR import all_code
+from pyqpanda_alg.QmRMR import QmRMR_core as all_code
 import warnings
 import os
 

--- a/pyqpanda-algorithm/example/QAlgBase/testeg_class_qsvr.py
+++ b/pyqpanda-algorithm/example/QAlgBase/testeg_class_qsvr.py
@@ -1,13 +1,12 @@
-from pyqpanda_alg.QFinance import class_qsvr
-import sympy as sp
 import numpy as np
-import pyqpanda as pq
+
+from pyqpanda_alg.QSVR import Quantum_SVR
+
 
 if __name__ == '__main__':
-    
     n_samples = 100
     n_features = 2
     X = np.random.rand(n_samples, n_features) * 10
     y = (2 * np.sin(X[:, 0]) +
          1.5 * np.cos(X[:, 1]))
-    class_qsvr.Quantum_SVR(X, y).show_res()
+    Quantum_SVR(X, y).show_res()

--- a/pyqpanda-algorithm/example/QAlgBase/testeg_comparator.py
+++ b/pyqpanda-algorithm/example/QAlgBase/testeg_comparator.py
@@ -1,44 +1,48 @@
-from pyqpanda_alg.QFinance import comparator
-import pyqpanda as pq
+from pyqpanda3.core import CPUQVM, QCircuit, QProg, H, X
+
+from pyqpanda_alg import QCmp
 
 
 if __name__ == '__main__':
     # 整数比较
     value = 3
-    m = pq.CPUQVM()
-    m.initQVM()
-    q_state = m.qAlloc_many(2)
-    q_anc_cmp = m.qAlloc_many(2)
-    prog = pq.QProg()
-    prog << pq.H(q_state)
-    cir = comparator.int_comparator(value, q_state, q_anc_cmp, function='g', reuse=True)
+    m = CPUQVM()
+    q_state = [0, 1]
+    q_anc_cmp = [2, 3]
+    prog = QProg()
+    cir = QCircuit()
+    for q in q_state:
+        cir << H(q)
+    cir << QCmp.int_comparator(value, q_state, q_anc_cmp, function='g', reuse=True)
     prog << cir
-    res = m.prob_run_dict(prog, [q_anc_cmp[-1]])
-    print(res)
+    m.run(prog, 1000)
+    print(m.result().get_prob_dict([q_anc_cmp[-1]]))
 
     # 插值方法
     value = 3.3
-    m = pq.CPUQVM()
-    m.initQVM()
-    q_state = m.qAlloc_many(3)
-    q_anc_cmp = m.qAlloc_many(3)
-    prog = pq.QProg()
-    prog << pq.X(q_state[:2])
-    cir = comparator.interpolation_comparator(value, q_state, q_anc_cmp, function='g', reuse=True)
+    m = CPUQVM()
+    q_state = [0, 1, 2]
+    q_anc_cmp = [3, 4, 5]
+    prog = QProg()
+    cir = QCircuit()
+    for q in q_state[:2]:
+        cir << X(q)
+    cir << QCmp.interpolation_comparator(value, q_state, q_anc_cmp, function='g', reuse=True)
     prog << cir
-    res = m.prob_run_dict(prog, [q_anc_cmp[-1]])
-    print(res)
+    m.run(prog, 1000)
+    print(m.result().get_prob_dict([q_anc_cmp[-1]]))
 
     # 两个态比较，示例中叠加态的0，1，2，3有0.5的概率大于态1
-    m = pq.CPUQVM()
-    m.initQVM()
-    q_state_1 = m.qAlloc_many(2)
-    q_state_2 = m.qAlloc_many(2)
-    q_anc_cmp = m.qAlloc_many(2)
-    prog = pq.QProg()
-    prog << pq.H(q_state_1)
-    prog << pq.X(q_state_2[0])
-    cir = comparator.qubit_comparator(q_state_1, q_state_2, q_anc_cmp, function='g')
+    m = CPUQVM()
+    q_state_1 = [0, 1]
+    q_state_2 = [2, 3]
+    q_anc_cmp = [4, 5]
+    prog = QProg()
+    cir = QCircuit()
+    for q in q_state_1:
+        cir << H(q)
+    cir << X(q_state_2[0])
+    cir << QCmp.qubit_comparator(q_state_1, q_state_2, q_anc_cmp, function='g')
     prog << cir
-    res = m.prob_run_dict(prog, [q_anc_cmp[-1]])
-    print(res)
+    m.run(prog, 1000)
+    print(m.result().get_prob_dict([q_anc_cmp[-1]]))

--- a/pyqpanda-algorithm/example/QAlgBase/testeg_grover_markdata.py
+++ b/pyqpanda-algorithm/example/QAlgBase/testeg_grover_markdata.py
@@ -1,24 +1,24 @@
-import pyqpanda as pq
-from pyqpanda_alg.QFinance import grover
+from pyqpanda3.core import CPUQVM, QProg
+
+from pyqpanda_alg.Grover import Grover, mark_data_reflection, iter_num, iter_analysis
 
 
 if __name__ == '__main__':
-    m = pq.CPUQVM()
-    m.initQVM()
-    q_state = m.qAlloc_many(3)
+    m = CPUQVM()
+    q_state = QProg(3).qubits()
 
     def mark(qubits):
-        return grover.mark_data_reflection(qubits=qubits, mark_data=['101', '001'])
+        return mark_data_reflection(qubits=qubits, mark_data=['101', '001'])
 
+    demo_search = Grover(flip_operator=mark)
+    best_iter = iter_num(q_num=len(q_state), sol_num=2)
+    print('best iter num: ', best_iter)
+    prob, angle = iter_analysis(q_num=len(q_state), sol_num=2, iternum=best_iter)
+    print('prob for getting one of the solution with given iter num:', prob)
 
-    demo_search = grover.Grover(flip_operator=mark)
-    # iter_num = grover.iter_num(q_num=len(q_state), sol_num=2)
-    # print('best iter num: ', iter_num)
-    # prob, angle = grover.iter_analysis(q_num=len(q_state), sol_num=2, iternum=iter_num)
-    # print('prob for getting one of the solution with given iter num:', prob)
-
-    prog = pq.QProg()
+    prog = QProg()
     prog << demo_search.cir(q_input=q_state)
 
-    res = m.prob_run_dict(prog, q_state)
+    m.run(prog, 1000)
+    res = m.result().get_prob_dict(q_state)
     print(res)

--- a/pyqpanda-algorithm/example/QAlgBase/testeg_t_spare.py
+++ b/pyqpanda-algorithm/example/QAlgBase/testeg_t_spare.py
@@ -1,6 +1,6 @@
 import numpy as np
 import matplotlib.pyplot as plt
-from pyqpanda_alg.QFinance.class_basic_sparecode import QSpare_Code
+from pyqpanda_alg.QSEncode import QSpare_Code
 def t01():
     mu = 0
     sigma = 1

--- a/pyqpanda-algorithm/pyqpanda_alg/Grover/Grover_core.py
+++ b/pyqpanda-algorithm/pyqpanda_alg/Grover/Grover_core.py
@@ -81,7 +81,7 @@ class Grover:
         Examples
             An example for implementing an Grover search for state where q_0 `and` q_1 is 1.
 
-        >>> from pyqpanda3.core import CPUQVM, QCircuit, Z, TOFFOLI
+        >>> from pyqpanda3.core import CPUQVM, QCircuit, QProg, Z, TOFFOLI
         >>> from pyqpanda_alg import Grover
         >>> m = CPUQVM()
         >>> q_state = list(range(3))

--- a/pyqpanda-algorithm/pyqpanda_alg/Grover/__init__.py
+++ b/pyqpanda-algorithm/pyqpanda_alg/Grover/__init__.py
@@ -1,5 +1,6 @@
 '''
-The QFinance module provides tools related to comparator, Quantum amplitude estimation, Grover algorithm, Grover optimization algorithm and QUBO problem solver, which are used to solve problems such as option pricing and portfolio optimization.
+The Grover module provides Grover search, its amplitude amplification operator and
+Grover adaptive search, used for unstructured search and combinatorial optimization.
 '''
 
 from .Grover_core import Grover,amp_operator,GroverAdaptiveSearch,mark_data_reflection,iter_num,iter_analysis

--- a/pyqpanda-algorithm/pyqpanda_alg/QAE/QAE.py
+++ b/pyqpanda-algorithm/pyqpanda_alg/QAE/QAE.py
@@ -349,7 +349,6 @@ class IQAE:
     def _measure(self, k: int, n_round: int) -> int:
         machine = self.machine
         qlist = self.qlist
-        clist = self.clist
 
         operator_g = amp_operator(in_operator=self.operatorA, q_input=qlist)
         prog = QProg()

--- a/pyqpanda-algorithm/pyqpanda_alg/QAOA/qaoa.py
+++ b/pyqpanda-algorithm/pyqpanda_alg/QAOA/qaoa.py
@@ -482,7 +482,6 @@ class QAOA:
 
         .. code-block:: python
 
-            import pyqpanda as pq
             import sympy as sp
             from pyqpanda_alg.QAOA.qaoa import *
 

--- a/pyqpanda-algorithm/pyqpanda_alg/QKmeans/QuantumKmeans.py
+++ b/pyqpanda-algorithm/pyqpanda_alg/QKmeans/QuantumKmeans.py
@@ -160,7 +160,6 @@ class QuantumKmeans:
 
 
         """
-        n = data.shape[0]
         c = data.shape[1]
 
         mean = np.mean(data, axis=0)

--- a/pyqpanda-algorithm/pyqpanda_alg/QSVD/QSVD.py
+++ b/pyqpanda-algorithm/pyqpanda_alg/QSVD/QSVD.py
@@ -153,7 +153,6 @@ class SVD:
         return abs(res)
 
     def max_eig(self, return_mat='0', par=None, max_index=0):
-        machine = CPUQVM()
         cir = QCircuit()
         ss = max_index % 2**self.q0
         bi0 = '{:b}'.format(ss).rjust(self.q0, '0')

--- a/pyqpanda-algorithm/pyqpanda_alg/QSVM/quantum_kernel_svm.py
+++ b/pyqpanda-algorithm/pyqpanda_alg/QSVM/quantum_kernel_svm.py
@@ -209,7 +209,6 @@ class QuantumKernel_vqnet:
 
                 import os
                 import numpy as np
-                import pyqpanda as pq
                 from sklearn.svm import SVC
                 import matplotlib
                 try:
@@ -350,8 +349,6 @@ class QuantumKernel_vqnet:
             mus = np.asarray(mus.flat)
             nus = np.asarray(nus.flat)
 
-        is_statevector_sim = False
-        measurement = not is_statevector_sim
         measurement_basis = "0" * self._n_qbits
 
         for idx in range(0, len(mus), self._batch_size):

--- a/pyqpanda-algorithm/pyqpanda_alg/QUBO/QUBO.py
+++ b/pyqpanda-algorithm/pyqpanda_alg/QUBO/QUBO.py
@@ -120,8 +120,6 @@ class QuadraticBinary:
         """
         n_key = np.max([1, len(self.linear), len(self.quadratic)])
 
-        bounds = []
-
         def pos(x): return x > 0
         def neg(x): return x < 0
 

--- a/pyqpanda-algorithm/pyqpanda_alg/QmRMR/__init__.py
+++ b/pyqpanda-algorithm/pyqpanda_alg/QmRMR/__init__.py
@@ -1,8 +1,9 @@
 '''
-The QFinance module provides tools related to comparator, Quantum amplitude estimation, Grover algorithm, Grover optimization algorithm and QUBO problem solver, which are used to solve problems such as option pricing and portfolio optimization.
+The QmRMR module provides quantum minimum-redundancy maximum-relevance feature
+selection, used to select an informative and non-redundant feature subset.
 '''
 
 
 from .QmRMR_core import Feature_Selection 
 
-__all__ = [Feature_Selection]
+__all__ = ['Feature_Selection']

--- a/pyqpanda-algorithm/pyqpanda_alg/plugin.py
+++ b/pyqpanda-algorithm/pyqpanda_alg/plugin.py
@@ -185,10 +185,11 @@ def qft(qubit_list: list[int]) -> QCircuit:
         >>> # << H(0)
         >>> 
         >>> # 嵌入主程序执行
-        >>> qvm = pq.QMachine(pq.QMachineType.CPU)
-        >>> main_prog = pq.QProg()
+        >>> from pyqpanda3.core import CPUQVM, QProg
+        >>> qvm = CPUQVM()
+        >>> main_prog = QProg()
         >>> main_prog << qft_circuit  # 添加QFT电路
-        >>> qvm.run(main_prog)
+        >>> qvm.run(main_prog, 1000)
     """
     pi = 3.141592653589793238462643383279502884
     
@@ -260,9 +261,10 @@ def QFT(qubit_list: list[int]) -> QCircuit:
         >>> # 交换部分：SWAP(0,2)
         >>> 
         >>> # 嵌入主程序执行
-        >>> qvm = pq.QMachine(pq.QMachineType.CPU)
-        >>> main_prog = pq.QProg() << qft_circuit
-        >>> qvm.run(main_prog)
+        >>> from pyqpanda3.core import CPUQVM, QProg
+        >>> qvm = CPUQVM()
+        >>> main_prog = QProg() << qft_circuit
+        >>> qvm.run(main_prog, 1000)
     """
     pi = 3.141592653589793238462643383279502884
     
@@ -331,9 +333,10 @@ def bind_nonnegative_data(value: int, qubit_list: list[int]) -> QCircuit:
         >>> # 电路包含：X(0) << X(2)（对应二进制101，低位在前）
         >>> 
         >>> # 验证：量子比特0和2被翻转为|1⟩，1保持|0⟩
-        >>> qvm = pq.QMachine(pq.QMachineType.CPU)
-        >>> main_prog = pq.QProg() << circuit
-        >>> qvm.run(main_prog)
+        >>> from pyqpanda3.core import CPUQVM, QProg
+        >>> qvm = CPUQVM()
+        >>> main_prog = QProg() << circuit
+        >>> qvm.run(main_prog, 1000)
     """
     # 输入验证：value必须为非负整数
     if not isinstance(value, int):
@@ -407,16 +410,16 @@ def parse_quantum_result_dict(result: Dict[str, float], qubit_list: List[int], s
         >>> qubit_list = [0, 1, 2]
         >>> 
         >>> # 1. 返回所有结果
-        >>> parse_quantum_result(raw_result, qubit_list)
+        >>> parse_quantum_result_dict(raw_result, qubit_list)
         {'000': 0.1, '111': 0.8, '010': 0.1}
         >>> 
         >>> # 2. 返回概率最高的1个结果
-        >>> parse_quantum_result(raw_result, qubit_list, select_max=1)
+        >>> parse_quantum_result_dict(raw_result, qubit_list, select_max=1)
         {'111': 0.8}
         >>> 
         >>> # 3. 返回概率最高的2个结果
-        >>> parse_quantum_result(raw_result, qubit_list, select_max=2)
-        {'111': 0.8, '000': 0.1, '010': 0.1}  # 概率相同则保留原始顺序
+        >>> parse_quantum_result_dict(raw_result, qubit_list, select_max=2)
+        {'111': 0.8, '000': 0.1}  # 概率相同则保留原始顺序
     """
     # 输入类型验证
     if not isinstance(result, dict):


### PR DESCRIPTION
修复 #38 中报告的全部问题。
关联 Issue：#38、#13 ｜ 参赛队伍：DU_Fanta

---

## 一、修复内容

### 1【Bug】`from pyqpanda_alg.QmRMR import *` 抛出 TypeError

`__all__` 中存放的是类对象而非名称字符串：

```python
- __all__ = [Feature_Selection]
+ __all__ = ['Feature_Selection']
```

修复前：

```python
>>> from pyqpanda_alg.QmRMR import *
TypeError: Item in pyqpanda_alg.QmRMR.__all__ must be str, not type
```

包内其余 12 个子模块本就使用字符串，此处为唯一例外。

### 2【Bug】`example/QAlgBase/` 中 8 个示例无法运行

两类原因，逐个修复：

- **`pyqpanda_alg.QFinance` 已不存在**：内容已拆分为 `QUBO` / `QCmp` / `QSVR` / `QSEncode`；
- **示例仍基于 pyqpanda v2**（`initQVM`、`qAlloc_many`、`prob_run_dict`），而本项目依赖为 pyqpanda3。

`testeg_QmRMR.py` 引用的 `all_code` 模块实际名为 `QmRMR_core`。

| 示例 | 修复前 | 修复后 |
| --- | --- | --- |
| `newtest.py` | ModuleNotFoundError: pyqpanda | OK |
| `testeg_QUBO.py` | ModuleNotFoundError: QFinance | OK |
| `testeg_QmRMR.py` | ImportError: all_code | OK |
| `testeg_class_qsvr.py` | ModuleNotFoundError: QFinance | OK |
| `testeg_comparator.py` | ModuleNotFoundError: QFinance | OK |
| `testeg_grover_markdata.py` | ModuleNotFoundError: pyqpanda | OK |
| `testeg_t_spare.py` | ModuleNotFoundError: QFinance | OK |
| `QmRMR/testeg_QmRMR.py` | ModuleNotFoundError: pyqpanda | OK |

11 个示例现全部可运行（`testeg_QSVD.py` 见下方说明）。

### 3【文档】5 处示例使用已移除的 pyqpanda v2 接口

`pq.QMachine(pq.QMachineType.CPU)` / `import pyqpanda as pq` → `CPUQVM()` / `QProg()`，涉及 `plugin.qft`、`plugin.QFT`、`plugin.bind_nonnegative_data`、`QSVM.quantum_kernel_svm`、`QAOA.qaoa`。`plugin` 的三处示例同时补上了所需的 import，可直接复制运行。

### 4【文档】`parse_quantum_result_dict` 示例调用不存在的函数

`parse_quantum_result` → `parse_quantum_result_dict`（3 处）。另修正 `select_max=2` 的示例输出：原文档列出 3 个条目，实际返回 2 个。

### 5【文档】`Grover.cir` 示例缺少 `QProg` 导入

### 6【文档】两个模块 docstring 描述了错误的模块

`Grover/__init__.py` 与 `QmRMR/__init__.py` 原均写作「The QFinance module provides...」，现改为各自模块的说明。

### 7【清理】6 处已赋值但从未读取的局部变量

`QAE`、`QKmeans`、`QSVD`、`QSVM`（2 处）、`QUBO`。`ruff check --select F841` 现无告警。

---

## 二、验证

```
$ cd test && python -m pytest QAlgBase QAOA QARM QPCA QSVM
18 passed

$ cd pyqpanda-algorithm/example/QAlgBase && for f in *.py QmRMR/*.py; do python "$f"; done
11 个示例全部通过（testeg_QSVD.py 除外，见下）

$ ruff check pyqpanda_alg --select F841
All checks passed!

$ python -c "from pyqpanda_alg.QmRMR import *"
（无报错）
```

可正常执行的 docstring 示例从 **33/40 提升到 39/40**。剩余 1 处为 `plugin.apply_QGate`，其使用标准 `...` 续行，本身写法正确，仅是检查脚本无法解析。

所有文件的 CRLF 行尾均保持不变，diff 中不含无关的行尾变动。

---

## 三、本 PR 未处理的问题

`example/QAlgBase/testeg_QSVD.py` 运行超过 300 秒未结束。已在**未修改的 develop** 上复现，确认为既有问题，与本 PR 无关，留待单独处理。

---

## English summary

Fixes everything reported in #38:

1. `pyqpanda_alg/QmRMR/__init__.py` put the class object in `__all__` instead of its name, so `from pyqpanda_alg.QmRMR import *` raised `TypeError`.
2. Eight of eleven example scripts did not run — they imported the removed `pyqpanda_alg.QFinance` package, or were still written against pyqpanda v2, which is not a dependency. All are ported to pyqpanda3.
3. Five docstring examples taught the removed v2 API (`pq.QMachine`, `import pyqpanda as pq`) and raised `ModuleNotFoundError` when copied.
4. `parse_quantum_result_dict`'s example called a non-existent `parse_quantum_result`, and its `select_max=2` output showed three entries instead of two.
5. `Grover.cir`'s example used `QProg` without importing it.
6. `Grover/__init__.py` and `QmRMR/__init__.py` both described "the QFinance module".
7. Six assigned-but-unread local variables removed; `ruff --select F841` is now clean.

18 existing tests still pass; executable docstring examples go from 33/40 to 39/40. CRLF line endings preserved throughout.

Not addressed: `testeg_QSVD.py` exceeds 300 s, which reproduces on unmodified `develop` and is therefore pre-existing.
