### PR TITLE
【代码贡献】Fix SPSA optimizer ignoring parameter bounds

### DIFF
--- a/pyqpanda-algorithm/pyqpanda_alg/QAOA/spsa.py
+++ b/pyqpanda-algorithm/pyqpanda_alg/QAOA/spsa.py
@@ -15,7 +15,7 @@ import numpy as np
 
 
 def _check_bounds(d, bounds):
-    """Check if the given bounds fits the variables."""
+    """Check if the given bounds fits the variables. Returns d (min, max) pairs, or None."""
     bounds = np.array(bounds)
     bn = len(bounds)
     if bn == 0:
@@ -29,8 +29,9 @@ def _check_bounds(d, bounds):
     elif bn > 1:
         if d != bn:
             raise IndexError('Dimension of ``bounds`` does not match the dimension of variable ``x``.')
+        return bounds
     elif bn == 1:
-        return bounds * d
+        return np.tile(bounds, (d, 1))
 
 
 def _jail_inside(x, bounds):

--- a/test/QAOA/Test_spsa_minimize.py
+++ b/test/QAOA/Test_spsa_minimize.py
@@ -54,5 +54,52 @@ class TestSPSAMinimize:
         # 验证回调函数被调用
         assert len(noise_function.history) > 0
         assert noise_function.eval_count > 0
-    
+
+    def test_spsa_bounds_respected(self, simple_function):
+        """Result stays inside per-variable bounds."""
+        np.random.seed(0)
+        x0 = np.array([5.0, 5.0])
+        bounds = [(1.0, 2.0), (1.0, 2.0)]
+
+        result = spsa.spsa_minimize(simple_function, x0, bounds=bounds, maxiter=100)
+
+        assert (result >= 1.0).all()
+        assert (result <= 2.0).all()
+
+    def test_spsa_single_pair_bounds_respected(self, simple_function):
+        """A single (min, max) pair applies to every variable."""
+        np.random.seed(0)
+        x0 = np.array([5.0, 5.0, 5.0])
+
+        result = spsa.spsa_minimize(simple_function, x0, bounds=[(1.0, 2.0)], maxiter=100)
+
+        assert result.shape == x0.shape
+        assert (result >= 1.0).all()
+        assert (result <= 2.0).all()
+
+    def test_check_bounds_per_variable(self):
+        """One pair per variable is returned as given."""
+        bounds = [(0.0, 1.0), (-2.0, 2.0), (3.0, 4.0)]
+
+        checked = spsa._check_bounds(3, bounds)
+
+        assert checked is not None
+        assert np.array_equal(checked, np.array(bounds))
+
+    def test_check_bounds_single_pair_tiled(self):
+        """A single pair is tiled, not multiplied."""
+        checked = spsa._check_bounds(3, [(0, 1)])
+
+        assert np.array_equal(checked, np.array([[0, 1], [0, 1], [0, 1]]))
+
+    def test_check_bounds_validation(self):
+        """Invalid bounds still raise, empty bounds still mean no bounds."""
+        with pytest.raises(ValueError):
+            spsa._check_bounds(2, [(2, 1), (0, 1)])
+
+        with pytest.raises(IndexError):
+            spsa._check_bounds(3, [(0, 1), (0, 1)])
+
+        assert spsa._check_bounds(2, []) is None
+
 


### PR DESCRIPTION
Relates to #13.

## Problem

`spsa_minimize` silently ignores the `bounds` argument in the normal case, and
corrupts it in the other case. The first path is what `QAOA.run(optimizer='SPSA')`
hits, since it always passes one pair per parameter; the second is reachable
through the documented `spsa_minimize(..., bounds=[(min, max)])` public API.

## Root cause

`pyqpanda_alg/QAOA/spsa.py`, `_check_bounds` (lines 17-33).

1. One `(min, max)` pair per variable, `len(bounds) == d`: the branch validates
   the dimension and then falls off the end of the function, so it returns
   `None`. `_jail_inside` reads `None` as "no bounds" and never clips.
2. One pair for all variables, `len(bounds) == 1`: `return bounds * d`
   multiplies the numpy array element-wise by `d` instead of repeating the row
   `d` times. `_check_bounds(3, [(0, 1)])` gives `[[0, 3]]`, which is the wrong
   interval and the wrong shape, so the later `np.clip` broadcasts one bogus
   pair over every variable.

## Fix

Return the validated array in the per-variable branch, and use `np.tile` for
the single-pair branch. The empty-bounds warning and both existing
`ValueError` / `IndexError` checks are unchanged.

## Verification

```python
import numpy as np
from pyqpanda_alg.QAOA.spsa import spsa_minimize, _check_bounds

np.random.seed(0)
f = lambda x: float(np.sum(x ** 2) - np.sum(x))   # unconstrained min at x = 0.5
print(spsa_minimize(f, np.array([5.0, 5.0]), bounds=[(1, 2), (1, 2)], maxiter=200))
print(_check_bounds(3, [(0, 1)]))
```

before

```
[0.5 0.5]                  <- outside [1, 2]
[[0 3]]
```

after

```
[1. 1.]
[[0 1]
 [0 1]
 [0 1]]
```

Same thing through `QAOA.run(optimizer='SPSA')` with
`gamma_bounds = beta_bounds = [(0.0, 0.5)]`: on `develop` the returned
parameters come back outside the bounds; with this change they stay inside.
With the default (unbounded) settings the result is bit-identical to `develop`.

## Tests

5 cases added to `test/QAOA/Test_spsa_minimize.py`: bounds respected end to end
for per-variable bounds and for a single tiled pair, `_check_bounds` returning
the array instead of `None`, single-pair tiling, and the existing validation
errors. Seeded, deterministic. 4 of the 5 fail on `develop` and pass with this
change.

```
pytest test/QAOA/Test_spsa_minimize.py     6 passed
cd test && pytest                          22 passed
```

The gradient line in `spsa_minimize` divides by `xp - xm` rather than
`2 * ck * delta`. With `delta` in `{-1, 1}` and no clipping these are
identical, and when clipping is active the current form is a finite difference
over the points actually evaluated, so I left it alone. Degenerate
`lo == hi` bounds make that denominator zero; that is a property of the
existing gradient line, not of this change, so it is out of scope here too.
