### PR TITLE
【代码贡献】Fix qft_qubit_comparator geq and s modes returning wrong results

### DIFF
--- a/pyqpanda-algorithm/pyqpanda_alg/QCmp/QCmp.py
+++ b/pyqpanda-algorithm/pyqpanda_alg/QCmp/QCmp.py
@@ -554,6 +554,12 @@ def qft_qubit_comparator(q_state_1, q_state_2, q_cmp, function='geq'):
 
     cir = QCircuit()
 
+    # the borrow bit gives q_state_1 > q_state_2, so 'geq' and 's' need the
+    # subtracted value shifted by one, same as the value += 1 in qft_comparator
+    if function == 'geq' or function == 's':
+        offset = 1
+    else:
+        offset = 0
 
     if not hasattr(q_cmp, '__len__'):
         q_cmp = [q_cmp]
@@ -572,6 +578,10 @@ def qft_qubit_comparator(q_state_1, q_state_2, q_cmp, function='geq'):
         for j, qj in enumerate(qlist):
             cir << U1(qj, -factor_all * 2 ** j * wi).control(q_state_1[i])
 
+    if offset:
+        for j, qj in enumerate(qlist):
+            cir << U1(qj, -factor_all * 2 ** j * offset)
+
     cir << QFT(qlist).dagger()
 
     cir << QFT(q_state_2)
@@ -579,6 +589,9 @@ def qft_qubit_comparator(q_state_1, q_state_2, q_cmp, function='geq'):
         for j, qj in enumerate(qlist):
             cir << U1(qj, factor_remain * 2 ** j * wi).control(q_state_1[i])
 
+    if offset:
+        for j, qj in enumerate(q_state_2):
+            cir << U1(qj, factor_remain * 2 ** j * offset)
 
     cir << QFT(q_state_2).dagger()
 

--- a/test/QAlgBase/Test_comparator_qft_qubit_comparator.py
+++ b/test/QAlgBase/Test_comparator_qft_qubit_comparator.py
@@ -1,30 +1,120 @@
-# import pytest
-# from pyqpanda_alg.QCmp import qft_qubit_comparator
-# from pyqpanda3.core import *
-#
-# class Test_comparator_qft_qubit_comparator:
-#
-#     def setup_method(self):
-#         self.machine = CPUQVM()
-#
-#     def test_qft_qubit_comparator_example_from_doc(self):
-#         prog = QProg()
-#         prog << H(0) << H(1)
-#         prog << X(3)
-#
-#         cir = qft_qubit_comparator([0, 1], [2, 3], [4], function='g')
-#         prog << cir
-#
-#         self.machine.run(prog, 1000)
-#         prob_dict_result = self.machine.result().get_prob_dict([4])
-#         prob_high = prob_dict_result.get('1', 0.0)
-#         expected_prob = 0.5
-#         tolerance = 0.3
-#
-#         assert abs(prob_high - expected_prob) < tolerance, (
-#             f"期望概率 {expected_prob:.4f}, 实际概率 {prob_high:.4f}, 超出容忍范围"
-#         )
-#
-#
-# if __name__ == "__main__":
-#     pytest.main([__file__, "-v", "-s"])
+import pytest
+from pyqpanda_alg.QCmp import qft_qubit_comparator
+from pyqpanda3.core import *
+
+
+PREDICATES = {
+    'g': lambda a, b: a > b,
+    'geq': lambda a, b: a >= b,
+    's': lambda a, b: a < b,
+    'seq': lambda a, b: a <= b,
+}
+
+
+class Test_comparator_qft_qubit_comparator:
+
+    def setup_method(self):
+        self.machine = CPUQVM()
+
+    def _prob_high(self, prog, q_cmp):
+        self.machine.run(prog, 1000)
+        return self.machine.result().get_prob_dict([q_cmp]).get('1', 0.0)
+
+    def _basis_prob(self, n, a, b, function):
+        # q_state_1 = 0..n-1, q_state_2 = n..2n-1, q_cmp = 2n, lowest index is LSB
+        q_state_1 = list(range(n))
+        q_state_2 = list(range(n, 2 * n))
+        q_cmp = 2 * n
+
+        prog = QProg()
+        for j in range(n):
+            if (a >> j) & 1:
+                prog << X(q_state_1[j])
+            if (b >> j) & 1:
+                prog << X(q_state_2[j])
+        prog << qft_qubit_comparator(q_state_1, q_state_2, [q_cmp], function=function)
+        return self._prob_high(prog, q_cmp)
+
+    def test_qft_qubit_comparator_example_from_doc(self):
+        prog = QProg()
+        prog << H(0) << H(1)
+        prog << X(3)
+
+        cir = qft_qubit_comparator([0, 1], [2, 3], [4], function='g')
+        prog << cir
+
+        prob_high = self._prob_high(prog, 4)
+        # uniform state over 0..3 compared with 2, only 3 is greater
+        assert abs(prob_high - 0.25) < 1e-6, (
+            f"expected 0.2500, got {prob_high:.4f}"
+        )
+
+    @pytest.mark.parametrize("function, expected", [
+        ('g', 0.25),
+        ('geq', 0.50),
+        ('s', 0.50),
+        ('seq', 0.75),
+    ])
+    def test_superposition_all_functions(self, function, expected):
+        prog = QProg()
+        prog << H(0) << H(1)
+        prog << X(3)
+
+        prog << qft_qubit_comparator([0, 1], [2, 3], [4], function=function)
+
+        prob_high = self._prob_high(prog, 4)
+        assert abs(prob_high - expected) < 1e-6, (
+            f"function={function}: expected {expected:.4f}, got {prob_high:.4f}"
+        )
+
+    @pytest.mark.parametrize("function", ['g', 'geq', 's', 'seq'])
+    def test_equality_boundary(self, function):
+        # a == b separates g from geq and s from seq
+        expected = 1.0 if PREDICATES[function](2, 2) else 0.0
+        prob_high = self._basis_prob(2, 2, 2, function)
+        assert abs(prob_high - expected) < 1e-6, (
+            f"function={function}, a=b=2: expected {expected:.4f}, got {prob_high:.4f}"
+        )
+
+    @pytest.mark.parametrize("function", ['g', 'geq', 's', 'seq'])
+    def test_all_basis_pairs_two_qubits(self, function):
+        for a in range(4):
+            for b in range(4):
+                expected = 1.0 if PREDICATES[function](a, b) else 0.0
+                prob_high = self._basis_prob(2, a, b, function)
+                assert abs(prob_high - expected) < 1e-6, (
+                    f"function={function}, a={a}, b={b}: "
+                    f"expected {expected:.4f}, got {prob_high:.4f}"
+                )
+
+    @pytest.mark.parametrize("function", ['g', 'geq', 's', 'seq'])
+    def test_all_basis_pairs_three_qubits(self, function):
+        for a in range(8):
+            for b in range(8):
+                expected = 1.0 if PREDICATES[function](a, b) else 0.0
+                prob_high = self._basis_prob(3, a, b, function)
+                assert abs(prob_high - expected) < 1e-6, (
+                    f"function={function}, a={a}, b={b}: "
+                    f"expected {expected:.4f}, got {prob_high:.4f}"
+                )
+
+    def test_state_registers_restored(self):
+        prog = QProg()
+        prog << H(0) << H(1) << H(2) << X(3)
+        prog << qft_qubit_comparator([0, 1], [2, 3], [4], function='geq')
+
+        self.machine.run(prog, 1000)
+        prob_dict = self.machine.result().get_prob_dict([0, 1, 2, 3])
+        for state, prob in prob_dict.items():
+            expected = 0.125 if state[0] == '1' else 0.0
+            assert abs(prob - expected) < 1e-6, (
+                f"state {state}: expected {expected:.4f}, got {prob:.4f}"
+            )
+
+    def test_unknown_function_raises(self):
+        with pytest.raises(NameError):
+            qft_qubit_comparator([0, 1], [2, 3], [4], function='eq')
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
## Problem

`QCmp.qft_qubit_comparator` builds the same circuit for `function='geq'` as for
`'g'`, and the same circuit for `'s'` as for `'seq'`. The two strict/non-strict
pairs are indistinguishable, so two of the four documented modes are wrong
whenever the two registers can be equal.

Repro, `q_state_1` in uniform superposition over 0..3 and `q_state_2 = |2>`:

```python
prog = QProg()
prog << H(0) << H(1) << X(3)
prog << QCmp.qft_qubit_comparator([0, 1], [2, 3], [4], function='geq')
```

| function | qft_qubit_comparator | qubit_comparator | qft_comparator | expected |
|---|---|---|---|---|
| g   | 0.25 | 0.25 | 0.25 | 0.25 |
| geq | 0.25 | 0.50 | 0.50 | 0.50 |
| s   | 0.75 | 0.50 | 0.50 | 0.50 |
| seq | 0.75 | 0.75 | 0.75 | 0.75 |

`qubit_comparator` and `qft_comparator` agree with each other on the same case;
`qft_qubit_comparator` disagrees on `geq` and `s`.

## Root cause

`pyqpanda-algorithm/pyqpanda_alg/QCmp/QCmp.py`, `qft_qubit_comparator`
(lines 512-592 before this change).

Both QFT comparators work the same way: subtract the compared value from the
`q_state + q_cmp` register, then add it back into `q_state` alone, which leaves
`q_cmp` holding the borrow bit and restores the state register. The borrow bit
is a strict comparison, so the non-strict mode has to shift the subtracted value
by one.

`qft_comparator` does that at line 480:

```python
if function == 'seq' or function == 'g':
    value += 1
```

`qft_qubit_comparator` has no equivalent. Its subtracted value comes from
controlled `U1` phases with `q_state_1` as controls, so there is nowhere
for a `value += 1` to go, and the constant term was simply never added. The
borrow bit therefore always evaluates `q_state_1 > q_state_2`, and the only
thing `function` still controls is the final `X(q_cmp)`, giving `g` == `geq` and
`s` == `seq`.

## Fix

Add the constant `1` to the same QFT-adder phase construction, for the two modes
that need it. In the `q_state_2 + q_cmp` block it goes in with `-factor_all`, in
the `q_state_2` restore block with `+factor_remain`, so the state register still
comes back unchanged:

```python
if function == 'geq' or function == 's':
    offset = 1
else:
    offset = 0
...
if offset:
    for j, qj in enumerate(qlist):
        cir << U1(qj, -factor_all * 2 ** j * offset)
...
if offset:
    for j, qj in enumerate(q_state_2):
        cir << U1(qj, factor_remain * 2 ** j * offset)
```

Uncontrolled gates, so the cost is `2n + 1` extra `U1`s and nothing at
all for `g` and `seq`. `g` and `seq` produce byte-identical circuits to before,
so the docstring example and `demo16-comparator-qft_qubit_comparator.ipynb`
(both `function='g'`) are unaffected.

## Verification

The repro table above now reads 0.25 / 0.50 / 0.50 / 0.75, matching
`qubit_comparator` and `qft_comparator`.

Exhaustive check over computational-basis pairs, asserting the comparison qubit
against the classical predicate for every `(a, b)`:

- 2-qubit registers, 4 modes x 16 pairs: 64/64 pass (8 failed before the fix,
  all of them `a == b` under `geq` or `s`)
- 3-qubit registers, 4 modes x 64 pairs: 256/256 pass
- 4-qubit registers, 4 modes x 256 pairs: 1024/1024 pass

Also checked that `q_state_1` and `q_state_2` are returned unchanged: feeding a
superposition through the `geq` circuit leaves the joint distribution over the
state qubits identical to the input.

## Tests

`test/QAlgBase/Test_comparator_qft_qubit_comparator.py` existed but every line
was commented out, so nothing covered this. Un-commented it, brought it up to
the current pyqpanda3 API, and extended it to 19 tests: the docstring example,
all four modes on the superposition case with exact expected probabilities, the
`a == b` boundary that separates `g` from `geq` and `s` from `seq`, exhaustive
basis-pair sweeps at 2 and 3 qubits, register restoration, and the `NameError`
on an unknown `function`.

```bash
cd test && python -m pytest -o addopts="" -q
# 36 passed  (17 before, 19 new)
```
