### PR TITLE
【代码贡献】Fix QPCA crash on 4-feature input and k=2 returning 0

### DIFF
--- a/pyqpanda-algorithm/pyqpanda_alg/QPCA/QPCA.py
+++ b/pyqpanda-algorithm/pyqpanda_alg/QPCA/QPCA.py
@@ -13,7 +13,6 @@
 from pyqpanda3.core import CPUQVM, QCircuit, QProg, TOFFOLI, SWAP, CNOT, U1, U3, CR, I, H, X, Y, measure
 import numpy as np
 import math
-import sys
 
 from .. plugin import *
 
@@ -201,15 +200,22 @@ def qpca(sample_A, k):
     """
     QPCA is a quantum version of the classical PCA algorithm, which is widely used in data analysis and machine learning.
 
+    Only 2-feature input is supported. The n=4 branches of the circuit helpers
+    are incomplete, so a larger input raises NotImplementedError.
+
     Parameters:
         sample_A: ``ndarray``\n
-            the input matrix for analysis
+            the input matrix for analysis, shape (n_samples, 2)
         k: ``int``\n
-            the dimension to reduce
+            the dimension to reduce, 1 or 2
 
     Returns:
         out: ``ndarray``\n
-            the output matrix after reducing dimension
+            the output matrix after reducing dimension, shape (n_samples, k)
+
+    Raises:
+        ValueError: k is not 1 or 2.\n
+        NotImplementedError: sample_A has other than 2 features.
 
     Examples:
         .. code-block:: python
@@ -222,61 +228,55 @@ def qpca(sample_A, k):
             print(data_q)
     """
     norm_x, A = _preprocessing(sample_A)
-    lambda_A, vector_A = np.linalg.eig(A)
-    A1 = A.reshape(1, 2 ** A.shape[0])[0]
+    n = A.shape[0]
+    if n != 2:
+        raise NotImplementedError(
+            'qpca supports 2-feature input only, got %d features' % n)
+    if k not in (1, 2):
+        raise ValueError('k must be 1 or 2, got %r' % (k,))
+
+    # the covariance matrix is symmetric, so eigh gives real eigenvalues and an
+    # orthonormal basis. sorted descending, principal component first.
+    lambda_A, vector_A = np.linalg.eigh(A)
+    order = np.argsort(lambda_A)[::-1]
+    lambda_A = lambda_A[order]
+    vector_A = vector_A[:, order]
+    A1 = A.reshape(1, 2 ** n)[0]
     state_vector = np.sqrt(1 / np.sum(A1 * A1)) * A1
 
-    if A.shape[0] == 2:
-        if k == 2:
-            tao = min(lambda_A) - 1
-        elif k == 1:
-            tao = np.sum(lambda_A)/2
-        else:
-            print('The K Error!')
-            sys.exit()
-        qm = _QMachine(5, 5)
-    if A.shape[0] == 4:
-        qm = _QMachine(8, 8)
+    # tao is the eigenvalue threshold. k=1 keeps the top eigenvalue only,
+    # k=2 sits below both and keeps the whole space.
+    if k == 2:
+        tao = min(lambda_A) - 1
+    else:
+        tao = np.sum(lambda_A) / 2
+    qm = _QMachine(5, 5)
 
     prog = QProg()
     cir = QCircuit()
-    _init_cir(qm, state_vector, A.shape[0])
-    cir << _phase_estimation_cir(qm.q_list, lambda_A, tao, A.shape[0])
-    cir << _transition_cir(qm.q_list, A.shape[0])
+    _init_cir(qm, state_vector, n)
+    cir << _phase_estimation_cir(qm.q_list, lambda_A, tao, n)
+    cir << _transition_cir(qm.q_list, n)
     cir << _cnot_cir(qm.q_list)
-    cir << _transition_reverse_cir(qm.q_list, A.shape[0])
-    cir << _phase_estimation_reverse_cir(qm.q_list, lambda_A, tao, A.shape[0])
+    cir << _transition_reverse_cir(qm.q_list, n)
+    cir << _phase_estimation_reverse_cir(qm.q_list, lambda_A, tao, n)
     prog << cir
     prog <<_measure_cir(prog, qm.q_list, qm.q_list)
-    # result = qm.machine.run_with_configuration(prog, qm.c_list, 8192)
     qm.machine.run(prog, 8192)
     result = qm.machine.result().get_prob_dict(qm.q_list)
-    a = []
-    data = 0
-    if A.shape[0] == 2:
-        for i, v in enumerate(result.keys()):
-            if int(v[-1]) == 1:
-                # a.append(float("%.4f" % (result[v] / 8192)))
-                a.append(float("%.4f" % (result[v])))
-        if k == 2:
-            result_idealA = state_vector
-        if k == 1:
-            i = np.argmax(lambda_A)
-            result_idealA = (np.kron(vector_A[:, i], vector_A[:, i]) * lambda_A[i]) / (
-                np.sqrt(lambda_A[i] * lambda_A[i]))
-        result_idealA1 = []
-        for i in range(len(result_idealA)):
-            if result_idealA[i] != 0:
-                result_idealA1.append(result_idealA[i])
-        result_idealA = result_idealA1
-        sum_A = np.sum(np.array(a))
-        result_circuitA = []
-        for i in range(len(a)):
-            result_circuitA.append(np.sqrt(a[i] / sum_A))
-        if k == 1:
-            vector_qpca = []
-            vector_qpca.append(np.sqrt(result_circuitA[0]))
-            vector_qpca.append(np.sqrt(result_circuitA[-1]))
-            vector_qpca = np.array(vector_qpca).reshape(1, 2)
-            data = np.dot(norm_x, np.transpose(vector_qpca))
-    return data
+
+    if k == 2:
+        # tao is below every eigenvalue, so post-selection succeeds with
+        # probability 1 and nothing is filtered out. the retained subspace is
+        # the whole feature space and its basis comes from vector_A.
+        return np.dot(norm_x, vector_A)
+
+    # post-select the ancilla, qubit 0, which is the last character of the key.
+    # sorted() so the branch order does not depend on dict insertion order.
+    a = [result[v] for v in sorted(result) if int(v[-1]) == 1]
+    sum_A = np.sum(np.array(a))
+    # probabilities back to amplitudes. unit norm when post-selection leaves
+    # two outcomes, which is the non-degenerate case.
+    result_circuitA = [np.sqrt(x / sum_A) for x in a]
+    vector_qpca = np.array([result_circuitA[0], result_circuitA[-1]]).reshape(1, 2)
+    return np.dot(norm_x, np.transpose(vector_qpca))

--- a/test/QPCA/Test_qpca.py
+++ b/test/QPCA/Test_qpca.py
@@ -8,6 +8,15 @@ import numpy as np
 sys.path.append((Path.cwd().parent.parent).__str__())
 
 
+def _classical_pca(x):
+    """Reference PCA: eigendecomposition of the covariance matrix, descending."""
+    norm_x = x - x.mean(axis=0)
+    cov = np.dot(norm_x.T, norm_x)
+    w, v = np.linalg.eigh(cov)
+    order = np.argsort(w)[::-1]
+    return norm_x, w[order], v[:, order]
+
+
 class TestQPCA:
     """QPCA测试类"""
 
@@ -15,6 +24,11 @@ class TestQPCA:
     def sample_data(self):
         """提供标准测试数据"""
         return np.array([[-1, 2], [-2, -1], [-1, -2], [1, 3], [2, 1], [3, 2]])
+
+    @pytest.fixture
+    def sample_data_4d(self):
+        rng = np.random.RandomState(0)
+        return rng.randn(20, 4)
 
     def test_qpca_normal(self, sample_data):
         """测试QPCA正常功能"""
@@ -26,5 +40,64 @@ class TestQPCA:
         assert data_q.shape == (6,1)
         assert isinstance(data_q, np.ndarray)
 
+    def test_qpca_k1_matches_classical_pca(self, sample_data):
+        from pyqpanda_alg.QPCA import qpca
 
+        data_q = qpca(sample_data, 1)[:, 0]
+        norm_x, _, v = _classical_pca(sample_data)
+        expected = np.dot(norm_x, v[:, 0])
+        if np.dot(data_q, expected) < 0:
+            expected = -expected
 
+        # sampling noise on 8192 shots keeps this loose
+        assert np.corrcoef(data_q, expected)[0, 1] > 0.999
+        assert np.max(np.abs(data_q - expected)) < 0.15
+
+    def test_qpca_k1_direction_is_unit_norm(self, sample_data):
+        """Holds for this fixture, not in general: a degenerate spectrum leaves
+        the post-selection with a single outcome and the norm comes out at
+        sqrt(2). Pinned to the documented example on purpose."""
+        from pyqpanda_alg.QPCA import qpca
+
+        norm_x, _, _ = _classical_pca(sample_data)
+        data_q = qpca(sample_data, 1)
+        # recover the projection direction the circuit produced
+        vec = np.linalg.lstsq(norm_x, data_q, rcond=None)[0][:, 0]
+        assert np.linalg.norm(vec) == pytest.approx(1.0, abs=1e-6)
+
+    def test_qpca_k2_returns_pca_scores(self, sample_data):
+        from pyqpanda_alg.QPCA import qpca
+
+        data_q = qpca(sample_data, 2)
+        norm_x, w, v = _classical_pca(sample_data)
+
+        assert isinstance(data_q, np.ndarray)
+        assert data_q.shape == (6, 2)
+
+        # PCA scores are decorrelated and carry the eigenvalues as their
+        # column variances, in descending order. neither holds for the
+        # centred input, so this pins the basis and not just the subspace.
+        cov_q = np.dot(data_q.T, data_q)
+        assert abs(cov_q[0, 1]) < 1e-9
+        assert np.allclose(np.diag(cov_q), w)
+
+        expected = np.dot(norm_x, v)
+        for j in range(2):
+            sign = np.sign(np.dot(data_q[:, j], expected[:, j]))
+            assert np.allclose(data_q[:, j], sign * expected[:, j])
+
+    @pytest.mark.parametrize('k', [0, 3, -1])
+    def test_qpca_invalid_k_raises(self, sample_data, k):
+        from pyqpanda_alg.QPCA import qpca
+
+        with pytest.raises(ValueError):
+            qpca(sample_data, k)
+
+    def test_qpca_four_features_raises(self, sample_data_4d):
+        from pyqpanda_alg.QPCA import qpca
+
+        with pytest.raises(NotImplementedError):
+            qpca(sample_data_4d, 1)
+
+        with pytest.raises(NotImplementedError):
+            qpca(sample_data_4d, 2)


### PR DESCRIPTION
## 问题 / Problem

Three of the four `qpca()` entry points are broken. Only `qpca(A, 1)` on a
2-feature input, the case in the docstring and the demo notebook, works.

```python
A = np.array([[-1, 2], [-2, -1], [-1, -2], [1, 3], [2, 1], [3, 2]])
qpca(A, 2)            # returns the literal int 0
qpca(A, 3)            # prints 'The K Error!' and kills the interpreter
qpca(np.random.randn(20, 4), 1)
# UnboundLocalError: cannot access local variable 'tao'
```

## 原因 / Root cause

1. `tao` and `qm` are only assigned inside the `A.shape[0] == 2` branch. The
   `A.shape[0] == 4` branch assigns `qm` but never `tao`, so the next line
   raises `UnboundLocalError`. This is specific to 4 features: other feature
   counts fail earlier and more clearly at `A.reshape(1, 2 ** n)`, since the
   covariance matrix has n² entries and the reshape asks for 2ⁿ, which agree
   only at n=2 and n=4.

   ```
   n=1  ValueError: cannot reshape array of size 1 into shape (1,2)
   n=3  ValueError: cannot reshape array of size 9 into shape (1,8)
   n=4  UnboundLocalError: cannot access local variable 'tao'
   n=5  ValueError: cannot reshape array of size 25 into shape (1,32)
   ```

2. `data = 0` is initialised and only overwritten inside `if k == 1`, so
   `qpca(A, 2)` falls through and returns the integer 0.
3. Invalid `k` calls `sys.exit()`, which terminates the caller's process
   instead of raising.
4. The k=1 projection vector takes `np.sqrt` twice. `result_circuitA` is
   already the amplitude vector, and on a non-degenerate spectrum the
   post-selection leaves two outcomes, so dividing by `sum_A` already makes it
   unit norm. Taking its square root again gives a vector of norm 2^(1/4) =
   1.1892, so every projected coordinate came out 18.9% too large.

I also checked the n=4 circuit code before deciding what to do with it. Wiring
`tao`/`qm` by hand is not enough to make it work:

- the post-selected branch has probability 0. The n=4 program ends in
  `|00000000>` with probability 1, so the ancilla the algorithm post-selects on
  never flips and there is no output to read.
- there is no n=4 result extraction at all. Everything after `get_prob_dict`
  sits inside `if A.shape[0] == 2`.
- `_init_cir` ignores its `state_vector` argument, so nothing is amplitude
  encoded and the register the n=4 path would need is never populated.

Finishing that path means writing the state preparation and the extraction
step, which is a feature, not a bugfix. I left the n=4 circuit code in place
and gated the entry point instead.

## 修改 / Fix

- Validate up front: a feature count other than 2 raises `NotImplementedError`
  with the count in the message, `k` outside {1, 2} raises `ValueError`. No
  more `UnboundLocalError`, no more `sys.exit()`.
- `k=2` returns the actual PCA scores. `tao = min(lambda) - 1` puts the
  threshold below every eigenvalue, and the circuit confirms this: the
  post-selection succeeds with probability 1, so the algorithm reports that
  nothing is filtered out. The retained subspace is therefore the whole
  feature space, and the basis for it is taken from the eigendecomposition the
  module already computes. Output is `norm_x @ V`.
- Switched that decomposition from `np.linalg.eig` to `np.linalg.eigh`. The
  covariance matrix is symmetric by construction, so this guarantees real
  eigenvalues and an orthonormal basis, and the components are sorted
  descending. `tao` is unaffected, it only reads `min`, `max` and `sum`.
- Removed the extra `np.sqrt` on the k=1 projection direction.
- Dropped the dead `result_idealA` block, which was computed and then never
  read, and the now unused `import sys`.
- Hardening, not a fix: post-selected keys are now read in `sorted()` order so
  component assignment does not lean on dict insertion order. On this circuit
  the two keys already came back sorted and at equal probability, so nothing
  observable changes.

## 数值验证 / Numerical validation

Compared against classical PCA, numpy eigendecomposition of the same
covariance matrix, on the docstring example. Eigenvalues are 30.4194 and
7.7472.

k=1, quantum output averaged over 20 runs (the circuit samples 8192 shots, so
it carries sampling noise of about 0.01 per coordinate):

| row | classical | qpca after fix | qpca before fix |
|---|---|---|---|
| 1 | -0.1373 | -0.1144 | -0.1361 |
| 2 | -2.9500 | -2.9455 | -3.5028 |
| 3 | -2.9344 | -2.9482 | -3.5061 |
| 4 |  1.9917 |  2.0054 |  2.3849 |
| 5 |  1.3080 |  1.2943 |  1.5392 |
| 6 |  2.7221 |  2.7085 |  3.2209 |

Max absolute error against classical drops from 0.5716 to 0.0229, which is
19.4% down to 0.78% of the largest coordinate. Correlation with the classical
projection is 0.99998. The recovered projection direction has norm 0.99997
against 1.1892 before, and sits 0.74 degrees off the classical principal
component.

k=2, previously the integer 0, now a (6, 2) array:

```
covariance of the output      [[30.4194, -1.4e-15],
                               [-1.4e-15,   7.7472]]
off-diagonal                  -1.4e-15          (was 11.3333)
column variances              30.4194, 7.7472   (was 19.3333, 18.8333)
eigenvalues, descending       30.4194, 7.7472
```

The scores are decorrelated and their column variances are the eigenvalues in
descending order, which is what distinguishes PCA output from the centred
input sitting in the original feature basis.

## 测试 / Tests

`test/QPCA/Test_qpca.py`, 8 tests, up from 1. The original `test_qpca_normal`
is untouched, the diff against develop is pure insertion. Added: k=1 against
classical PCA, k=1 projection direction is unit norm on the documented
example, k=2 decorrelation plus column variances plus per-column equality with
the classical scores, invalid k raises `ValueError` (parametrised over 0, 3,
-1), 4-feature input raises `NotImplementedError` for both k=1 and k=2.

```bash
python -m pytest test/QPCA -o addopts="" -q     # 8 passed
python -m pytest test      -o addopts="" -q     # 25 passed, was 18 on develop
```

Ran the QPCA file 10 times in a row to check the tolerances hold against shot
noise. The demo notebook
`pyqpanda-algorithm/test/07-QPCA/demo01-QPCA-qpca.ipynb` uses k=1 and still
runs.

## 已知限制（既有行为，本 PR 未改动） / Known limitation (pre-existing, unchanged by this PR)

This is existing upstream behaviour; this PR neither introduces nor changes
it. Flagging it so the numbers above are not read as more than they are.

The phase estimation gates are constants and `_init_cir` never encodes
`state_vector`, so the input matrix only reaches the circuit through the `tao`
branch comparison. The k=1 direction the circuit returns is therefore always
[1/sqrt(2), 1/sqrt(2)], which coincides with the principal component of the
docstring example but is not correct for general input. On
`[[-3,3],[-2,2],[-1,1],[1,-1],[2,-2],[3,-3]]`, whose principal component is
[0.7071, -0.7071], classical PCA gives projections up to 4.24 while `qpca`
returns about 0.02.

The extraction is also sign-blind by construction: amplitudes are recovered as
square roots of measured probabilities, which are non-negative, so a principal
component with mixed signs can never be reproduced no matter what the circuit
does. Fixing this needs real state preparation and a data dependent evolution,
so I kept it out of this PR. Happy to open a separate one if that is wanted.
