### PR TITLE
【代码贡献】QSVR: build the show_res test grid from each column's own min/max

### DIFF
--- a/pyqpanda-algorithm/pyqpanda_alg/QSVR/QSVR.py
+++ b/pyqpanda-algorithm/pyqpanda_alg/QSVR/QSVR.py
@@ -134,8 +134,8 @@ class Quantum_SVR:
     def show_res(self):
         svr = SVR(kernel=self.k_kernel, gamma=0.1)
         svr.fit(self.x, self.y)
-        x0_test = np.linspace(min(self.x[:, 0]), max(self.x[:, 1]), 30)
-        x1_test = np.linspace(min(self.x[:, 0]), max(self.x[:, 1]), 30)
+        x0_test = np.linspace(min(self.x[:, 0]), max(self.x[:, 0]), 30)
+        x1_test = np.linspace(min(self.x[:, 1]), max(self.x[:, 1]), 30)
         X0_test, X1_test = np.meshgrid(x0_test, x1_test)
         X_test = np.c_[X0_test.ravel(), X1_test.ravel()]
         y_pred = svr.predict(X_test).reshape(X0_test.shape)

--- a/test/QAlgBase/Test_class_qsvr_Quantum_SVR.py
+++ b/test/QAlgBase/Test_class_qsvr_Quantum_SVR.py
@@ -2,8 +2,41 @@ import pytest
 import numpy as np
 import os
 from pyqpanda_alg.QSVR import Quantum_SVR
+from pyqpanda_alg.QSVR import QSVR as qsvr_module
 import warnings
 import os
+
+
+class _RecordingSVR:
+    def __init__(self):
+        self.seen = []
+
+    def fit(self, X, y):
+        return self
+
+    def predict(self, X):
+        X = np.asarray(X)
+        self.seen.append(X)
+        return np.zeros(len(X))
+
+
+class _FakeAxes:
+    def __getattr__(self, name):
+        return lambda *args, **kwargs: None
+
+
+class _FakeFigure:
+    def add_subplot(self, *args, **kwargs):
+        return _FakeAxes()
+
+
+def _grid_points(monkeypatch, qsvr):
+    svr = _RecordingSVR()
+    monkeypatch.setattr(qsvr_module, "SVR", lambda **kwargs: svr)
+    monkeypatch.setattr(qsvr_module.plt, "figure", lambda *args, **kwargs: _FakeFigure())
+    monkeypatch.setattr(qsvr_module.plt, "show", lambda *args, **kwargs: None)
+    qsvr.show_res()
+    return svr.seen[0]
 
 
 class Test_class_qsvr_Quantum_SVR:
@@ -37,6 +70,31 @@ class Test_class_qsvr_Quantum_SVR:
 
         except Exception as e:
             pytest.fail(f"show_res()方法执行失败: {e}")
+
+    def test_show_res_grid_matches_column_ranges(self, monkeypatch):
+        t = np.random.randn(60)
+        X = np.column_stack([t + 0.05 * np.random.randn(60), 20 * t + np.random.randn(60)])
+        qsvr = Quantum_SVR(X, np.sin(t))
+
+        points = _grid_points(monkeypatch, qsvr)
+
+        assert points.shape == (900, 2)
+        for col in (0, 1):
+            axis = np.unique(points[:, col])
+            assert len(axis) == 30
+            expected = np.linspace(qsvr.x[:, col].min(), qsvr.x[:, col].max(), 30)
+            assert np.allclose(axis, expected)
+
+    def test_show_res_grid_axes_are_independent(self, monkeypatch):
+        x = np.column_stack([np.linspace(0, 2, 40), np.linspace(10, 30, 40)])
+        qsvr = Quantum_SVR(x, np.zeros(40))
+        # bypass the scaler/PCA so the two columns keep exact, unmistakable ranges
+        qsvr.x = x
+
+        points = _grid_points(monkeypatch, qsvr)
+
+        assert np.allclose([points[:, 0].min(), points[:, 0].max()], [0.0, 2.0])
+        assert np.allclose([points[:, 1].min(), points[:, 1].max()], [10.0, 30.0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`Quantum_SVR.show_res()` draws the regression surface over the wrong region.
Both axes of the test grid get the same range, and that range is not the range
of either input column: it starts at column 0's minimum and ends at column 1's
maximum. The surface is therefore evaluated far outside the training data on one
axis, and the other axis covers an interval the data never occupies, so the plot
does not line up with the scatter points it is drawn against.

## Root cause

`pyqpanda_alg/QSVR/QSVR.py`, `show_res` (lines 137-138):

```python
x0_test = np.linspace(min(self.x[:, 0]), max(self.x[:, 1]), 30)
x1_test = np.linspace(min(self.x[:, 0]), max(self.x[:, 1]), 30)
```

The column index is crossed. Both lines take the minimum from column 0 and the
maximum from column 1, and the two lines are identical, so `x1_test` never sees
column 1's minimum and `x0_test` never sees column 0's maximum.

It is easy to miss because `__init__` runs `StandardScaler` and then PCA, which
usually leaves both columns centred near zero and roughly the same size. The
error is still there in that case: with a strongly correlated 2-feature input
(case B below), PC1 spans `[-4.12, 4.30]` and PC2 `[-0.12, 0.12]`, and both
plotted axes come out as `[-4.12, 0.12]`. It becomes obvious as soon as the
columns differ in scale, for instance when `self.x` is assigned directly, or
when a 1-column input is zero-padded and column 1 is constant 0.

## Fix

Take each axis from its own column:

```python
x0_test = np.linspace(min(self.x[:, 0]), max(self.x[:, 0]), 30)
x1_test = np.linspace(min(self.x[:, 1]), max(self.x[:, 1]), 30)
```

Two lines. The grid size, the meshgrid, the kernel, the fit and the plotting
calls are untouched, and `get_res()` is not affected.

## Verification

`show_res` is instrumented with a stub SVR so the grid it builds can be read
back without waiting on the quantum kernel, on three inputs whose columns have
different ranges. Case A sets `self.x` directly with column 0 in `[0, 2]` and
column 1 in `[10, 30]`. Case B goes through `__init__`, so the columns are the
PCA components of a correlated input: with `rng = numpy.random.default_rng(0)`,
`t = rng.normal(size=200)` and
`x = column_stack([t + 0.05*rng.normal(size=200), 20*t + rng.normal(size=200)])`.
Case C is a single-column input that the class zero-pads.

```
   data col0           data col1        before axis0        before axis1        after axis0         after axis1
A  [0, 2]              [10, 30]         [0.000, 30.000]     [0.000, 30.000]     [0.000, 2.000]      [10.000, 30.000]
B  [-4.119, 4.304]     [-0.119, 0.122]  [-4.119, 0.122]     [-4.119, 0.122]     [-4.119, 4.304]     [-0.119, 0.122]
C  [-1.936, 1.455]     [0, 0]           [-1.936, 0.000]     [-1.936, 0.000]     [-1.936, 1.455]     [0.000, 0.000]
```

The docstring example runs end to end with the real quantum kernel and the same
random data as before, and still completes in about 5 s.

## Tests

2 cases added to `test/QAlgBase/Test_class_qsvr_Quantum_SVR.py`. They swap in a
recording stub for `SVR` and for the pyplot figure, call `show_res()`, and read
the grid straight out of the points handed to `predict`: one asserts both axes
equal `linspace` over their own column's min and max for constructor-produced
data, the other pins the crisp case of column 0 in `[0, 2]` and column 1 in
`[10, 30]`. No figure is created and no quantum circuit is run, so both are fast
and deterministic. Both fail on `develop` and pass with this change.

```
cd test && python -m pytest -o addopts="" QAlgBase/Test_class_qsvr_Quantum_SVR.py -q
3 passed
cd test && python -m pytest -o addopts="" -q
19 passed          # 17 before this change
```

(`-o addopts=""` because `test/pytest.ini` hardcodes allure options that need
the `allure-pytest` plugin.)

`example/QAlgBase/testeg_class_qsvr.py` imports `pyqpanda_alg.QFinance.class_qsvr`,
which does not exist in this tree, and also imports `pyqpanda` rather than
`pyqpanda3`. That is a separate stale-example problem, unrelated to the grid
ranges, so I left it alone here.
