### PR TITLE
【代码贡献】修复 QARM 支持度与关联规则结果错误

### DIFF
--- a/pyqpanda-algorithm/pyqpanda_alg/QARM/qarm.py
+++ b/pyqpanda-algorithm/pyqpanda_alg/QARM/qarm.py
@@ -12,7 +12,6 @@
 
 import os
 import math
-import numpy as np
 from pyqpanda3.core import QCircuit, QProg, CPUQVM, X, H, U1, SWAP, draw_qprog
 from pyqpanda3.intermediate_compiler import convert_qprog_to_originir
 from pyqpanda3.qcloud import QCloudService
@@ -304,26 +303,35 @@ class QuantumAssociationRulesMining:
         return result
 
     def _iter_number(self):
-        estimate_count = math.floor(math.pi * math.sqrt(2 ** self.index_qubit_number) / 2)
-        if estimate_count % 2:
-            count = estimate_count
-        else:
-            count = estimate_count + 1
-        if count >= 9:
-            count -= 4
-        return count
+        # QARM uses a two-register Grover construction where the measured
+        # register alternates after each SWAP.  Odd t correspond to effective
+        # Grover steps k = (t-1)//2.  After one effective step (k=1, t=3),
+        # the marked/unmarked per-state probability separation is strictly
+        # positive whenever M/N < 1/2.  For the 3+ item quantum domain
+        # (items_qubit_number >= 2), M/N <= 1/4 is guaranteed, so t=3 is
+        # sufficient to recover all marked rows from the full probability
+        # distribution returned by get_prob_dict.
+        return 3
 
     def _get_result(self, qlist, clist, position, locating_number, _iter_number, show, file_name, machine_type):
         result = self._iter_cir(qlist, clist, position, locating_number, _iter_number, show, file_name, machine_type)
-        val_list = []
-        for val in result.values():
-            val_list.append(round(val, 4))
-        np_val_list = np.array(val_list)
-        max_val = np.max(np_val_list)
-        index = np.argwhere(np_val_list == max_val)
-        index = index.flatten().tolist()
-        result = self._get_index(index)
-        return result
+        if not result:
+            return []
+        # Find the maximum probability using the actual dictionary values
+        max_prob = max(result.values())
+        # Select all basis states whose probability is within relative
+        # tolerance of the maximum.  This avoids depending on dict insertion
+        # order and does not merge distinct probability levels via rounding.
+        max_keys = [int(k, 2) for k, v in result.items()
+                    if math.isclose(v, max_prob, rel_tol=1e-10)]
+        # Decode the selected keys into (transaction_index, item_index) tuples
+        decoded = self._get_index(max_keys)
+        # Structural filtering: keep only states that correspond to real
+        # transactions and to the target item (locating_number).
+        target_item_idx = locating_number - 1
+        filtered = [(tx, it) for tx, it in decoded
+                    if tx < self.transaction_number and it == target_item_idx]
+        return filtered
 
     def _get_index(self, index):
         result = []
@@ -338,11 +346,22 @@ class QuantumAssociationRulesMining:
     def _find_f1(self, qlist, clist, position, c1, show, file_name, machine_type):
         _iter_number = self._iter_number()
         ck_dict = {}
-        for data in c1:
-            locating_number = data[0]
-            result = self._get_result(qlist, clist, position, locating_number, _iter_number, show, file_name, machine_type)
-            row_index = [index[0] for index in result]
-            ck_dict[data] = row_index
+        # Two-item domain: M/N can reach 1/2, where no Grover iteration can
+        # separate marked from unmarked states.  Use exact classical row
+        # recovery from the already-loaded transaction matrix instead.
+        if self.items_qubit_number == 1:
+            for data in c1:
+                locating_number = data[0]
+                target_col = locating_number - 1
+                row_index = [n for n in range(self.transaction_number)
+                             if self.transaction_matrix[n][target_col] == locating_number]
+                ck_dict[data] = row_index
+        else:
+            for data in c1:
+                locating_number = data[0]
+                result = self._get_result(qlist, clist, position, locating_number, _iter_number, show, file_name, machine_type)
+                row_index = [index[0] for index in result]
+                ck_dict[data] = row_index
         f1_dict = {}
         f1 = []
         for key, val in ck_dict.items():

--- a/test/QARM/Test_QARM_search_correctness.py
+++ b/test/QARM/Test_QARM_search_correctness.py
@@ -1,0 +1,372 @@
+"""
+Regression tests for QARM singleton row recovery, support calculation,
+and probability-decoding correctness.
+
+The secondary _get_all_conf() rule-generation defect is not tested here.
+"""
+import sys
+import os
+from pathlib import Path
+import pytest
+from pyqpanda_alg.QARM import QuantumAssociationRulesMining
+from pyqpanda_alg import QARM
+
+sys.path.append(Path.cwd().parent.parent.__str__())
+
+
+# ============================================================
+# Helpers
+# ============================================================
+
+def read_dataset(file_path):
+    if os.path.exists(file_path):
+        trans_data = []
+        with open(file_path, 'r', encoding='utf8') as f:
+            for line in f:
+                if line.strip():
+                    data_list = line.strip().split(',')
+                    trans_data.append([data.strip() for data in data_list])
+        return trans_data
+    else:
+        raise FileNotFoundError(f'The file {file_path} does not exist!')
+
+
+def classical_exact_rows(transactions, target_item):
+    """Return sorted list of transaction indices containing target_item."""
+    return sorted(i for i, t in enumerate(transactions) if target_item in t)
+
+
+def classical_exact_support(transactions, target_item):
+    """Return exact support = len(rows) / len(transactions)."""
+    rows = classical_exact_rows(transactions, target_item)
+    return len(rows) / len(transactions)
+
+
+def qarm_f1_for_item(transactions, min_support, min_confidence, item_name):
+    """
+    Run the real _find_f1() and return (rows, support) for the named item.
+    This exercises the F1 row-recovery contract through _find_f1(),
+    including the two-item classical fallback.
+    """
+    from pyqpanda3.core import CPUQVM, QProg
+    qarm = QuantumAssociationRulesMining(transactions, min_support, min_confidence)
+    machine = CPUQVM()
+    qarm.machine = machine
+    prog = QProg(qarm.number_qubits)
+    qlist = prog.qubits()
+    clist = prog.cbits()
+    position = 0
+
+    c1 = qarm._create_c1(qarm.transaction_matrix)
+    f1, f1_dict = qarm._find_f1(qlist, clist, position, c1, None, "", "CPU")
+
+    # Find the item_id for the given item_name
+    item_id = None
+    for iid, iname in qarm.items_dict.items():
+        if iname == item_name:
+            item_id = iid
+            break
+    if item_id is None:
+        raise ValueError(f"Item '{item_name}' not found in dataset")
+
+    # Look up the item in f1_dict by its tuple key
+    target_key = (item_id,)
+    if target_key in f1_dict:
+        rows, support = f1_dict[target_key]
+        return sorted(rows), support
+    return [], 0.0
+
+
+def qarm_public_run(transactions, min_support, min_confidence):
+    """Run QARM public API and return the rule dictionary."""
+    qarm = QuantumAssociationRulesMining(transactions, min_support, min_confidence)
+    return qarm.run()
+
+
+# ============================================================
+# Fixtures
+# ============================================================
+
+@pytest.fixture
+def data2():
+    """Bundled data2.txt dataset."""
+    data_path = QARM.__path__[0]
+    return read_dataset(os.path.join(data_path, 'dataset/data2.txt'))
+
+
+@pytest.fixture
+def data2_ground_truth():
+    """Classical ground truth for all data2.txt items."""
+    data_path = QARM.__path__[0]
+    transactions = read_dataset(os.path.join(data_path, 'dataset/data2.txt'))
+    return {item: {
+        'rows': classical_exact_rows(transactions, item),
+        'support': classical_exact_support(transactions, item),
+    } for item in ['面包', '牛奶', '奶酪', '黄油']}
+
+
+@pytest.fixture
+def dense_3item_8txn():
+    """3 items, 8 txns. Target A in all 8. N=32, M=8, M/N=1/4."""
+    return [
+        ['A', 'B', 'C'], ['A', 'B'], ['A', 'C'], ['A', 'B', 'C'],
+        ['A', 'B'], ['A', 'C'], ['A', 'B', 'C'], ['A', 'B'],
+    ]
+
+
+@pytest.fixture
+def boundary_2item_4txn():
+    """2 items, 4 txns. Target A in all 4. N=8, M=4, M/N=1/2."""
+    return [
+        ['A', 'B'], ['A'], ['A', 'B'], ['A'],
+    ]
+
+
+@pytest.fixture
+def padded_3item_5txn():
+    """3 items, 5 txns (non-power-of-2). N=32, 3 padded tx states."""
+    return [
+        ['A', 'B'], ['A', 'C'], ['A', 'B'], ['B', 'C'], ['A', 'B'],
+    ]
+
+
+# ============================================================
+# Contract A+B: data2 F1 rows, support, and invariant
+# ============================================================
+
+class TestData2F1:
+    """data2.txt: QARM F1 rows/support must match classical, 0 <= s <= 1."""
+
+    @pytest.mark.parametrize("item_name", ['面包', '牛奶', '奶酪', '黄油'])
+    def test_f1_rows_and_support(self, data2, data2_ground_truth, item_name):
+        qarm_rows, qarm_support = qarm_f1_for_item(data2, 0.2, 0.5, item_name)
+        expected = data2_ground_truth[item_name]
+        assert qarm_rows == expected['rows'], \
+            f"F1 rows for '{item_name}': QARM={qarm_rows}, expected={expected['rows']}"
+        assert qarm_support == pytest.approx(expected['support'], abs=0.001), \
+            f"Support for '{item_name}': QARM={qarm_support:.4f}, expected={expected['support']:.4f}"
+        assert 0.0 <= qarm_support <= 1.0, \
+            f"Support for '{item_name}' = {qarm_support} violates [0,1] invariant"
+
+
+# ============================================================
+# Contract C: user-visible end-to-end rule
+# ============================================================
+
+class TestEndToEndRule:
+    """Public run() API: 牛奶->面包 confidence must be 0.80."""
+
+    def test_milk_to_bread_confidence(self, data2):
+        result = qarm_public_run(data2, 0.2, 0.5)
+        rule_key = '牛奶->面包'
+        assert rule_key in result, \
+            f"Rule '{rule_key}' not found in QARM output: {list(result.keys())}"
+        assert result[rule_key] == 0.8, \
+            f"'{rule_key}' confidence: expected 0.8, got {result[rule_key]}"
+
+
+# ============================================================
+# Contract D: dense 3-item quantum-path case (M/N=1/4)
+# ============================================================
+
+class TestDense3ItemCase:
+    """3 items, 8 txns: A in all 8. M/N=1/4, t=3 has maximal separation."""
+
+    def test_f1_rows_and_support(self, dense_3item_8txn):
+        qarm_rows, qarm_support = qarm_f1_for_item(dense_3item_8txn, 0.3, 0.5, 'A')
+        expected_rows = classical_exact_rows(dense_3item_8txn, 'A')
+        expected_support = classical_exact_support(dense_3item_8txn, 'A')
+        assert qarm_rows == expected_rows, \
+            f"Dense A rows: QARM={qarm_rows}, expected={expected_rows}"
+        assert qarm_support == pytest.approx(expected_support), \
+            f"Dense A support: QARM={qarm_support:.4f}, expected={expected_support:.4f}"
+        assert 0.0 <= qarm_support <= 1.0
+
+
+# ============================================================
+# Contract E: two-item fallback boundary (M/N=1/2)
+# ============================================================
+
+class TestTwoItemBoundary:
+    """2 items, 4 txns: A in all 4. M/N=1/2, Grover degeneracy."""
+
+    def test_f1_rows_and_support(self, boundary_2item_4txn):
+        qarm_rows, qarm_support = qarm_f1_for_item(boundary_2item_4txn, 0.3, 0.5, 'A')
+        expected_rows = classical_exact_rows(boundary_2item_4txn, 'A')
+        expected_support = classical_exact_support(boundary_2item_4txn, 'A')
+        assert qarm_rows == expected_rows, \
+            f"Boundary A rows: QARM={qarm_rows}, expected={expected_rows}"
+        assert qarm_support == pytest.approx(expected_support), \
+            f"Boundary A support: QARM={qarm_support:.4f}, expected={expected_support:.4f}"
+        assert 0.0 <= qarm_support <= 1.0
+
+
+# ============================================================
+# Contract F: padded search-space case
+# ============================================================
+
+class TestPaddedSpace:
+    """3 items, 5 txns (non-power-of-2): no padded indices, correct rows."""
+
+    def test_f1_rows_and_support(self, padded_3item_5txn):
+        qarm = QuantumAssociationRulesMining(padded_3item_5txn, 0.3, 0.5)
+        qarm_rows, qarm_support = qarm_f1_for_item(padded_3item_5txn, 0.3, 0.5, 'A')
+        expected_rows = classical_exact_rows(padded_3item_5txn, 'A')
+        expected_support = classical_exact_support(padded_3item_5txn, 'A')
+        assert all(r < qarm.transaction_number for r in qarm_rows), \
+            f"Padded indices found: {[r for r in qarm_rows if r >= qarm.transaction_number]}"
+        assert qarm_rows == expected_rows, \
+            f"Padded A rows: QARM={qarm_rows}, expected={expected_rows}"
+        assert qarm_support == pytest.approx(expected_support), \
+            f"Padded A support: QARM={qarm_support:.4f}, expected={expected_support:.4f}"
+        assert 0.0 <= qarm_support <= 1.0
+
+
+# ============================================================
+# Contract G: dictionary-order independence
+# ============================================================
+
+class TestDecodingOrderIndependence:
+    """
+    Prove that _get_result() correctness is invariant to
+    dictionary insertion order of get_prob_dict().
+    """
+
+    def test_result_independent_of_dict_order(self, monkeypatch):
+        """Monkeypatch _iter_cir to return a dict with non-ascending key order."""
+        data = [['A', 'B'], ['A'], ['B'], ['A', 'B']]
+        qarm = QuantumAssociationRulesMining(data, 0.3, 0.5)
+
+        # Crafted dict with non-ascending insertion order:
+        # key '010' (int 2) has the highest probability 0.98
+        # key '111' (int 7) and '000' (int 0) are low
+        # Inserted in order: 7, 2, 0
+        crafted_dict = {
+            '111': 0.01,   # key_int=7, dict position 0
+            '010': 0.98,   # key_int=2, dict position 1 — actual maximum
+            '000': 0.01,   # key_int=0, dict position 2
+        }
+
+        # Pre-fix failure chain:
+        #   max probability 0.98 belongs to key '010'
+        #   -> result.values() has maximum at position 1
+        #   -> the old code passes integer 1 to _get_index
+        #   -> integer 1 is decoded as basis state '001' (not '010')
+        #   -> wrong transaction/item returned
+        #
+        # Correct behaviour: use actual key '010' (int 2) directly.
+
+        def mock_iter_cir(*args, **kwargs):
+            return crafted_dict
+
+        monkeypatch.setattr(qarm, '_iter_cir', mock_iter_cir)
+
+        from pyqpanda3.core import CPUQVM, QProg
+        machine = CPUQVM()
+        qarm.machine = machine
+        prog = QProg(qarm.number_qubits)
+        qlist = prog.qubits()
+        clist = prog.cbits()
+        position = 0
+
+        result = qarm._get_result(qlist, clist, position, 1, 1, None, "", "CPU")
+
+        # With idx_qn=3, trans_qn=2, items_qn=1:
+        # key '010' (int 2) -> bin='010' -> tx=int('01',2)=1, item=int('0',2)=0
+        # key '001' (int 1, the WRONG result from position-based decoding) -> tx=0, item=1
+        assert len(result) == 1, f"Expected 1 result, got {len(result)}: {result}"
+        tx, item = result[0]
+        assert tx == 1, \
+            f"tx=1 expected from key '010', got tx={tx} (position-based gives tx=0)"
+        assert item == 0, \
+            f"item=0 expected from key '010', got item={item}"
+
+
+# ============================================================
+# Contract H: probability-plateau decoding (corrected)
+# ============================================================
+
+class TestDecodingPlateau:
+    """
+    Prove that decoding recovers all true maxima sharing the same
+    target item index, and excludes states that round to the same
+    4-decimal value but are genuinely lower.
+    """
+
+    def test_plateau_recovers_all_maxima(self, monkeypatch):
+        """Two true maxima at same item index, one rounding-impostor."""
+        data = [['A', 'B'], ['A'], ['B'], ['A', 'B']]
+        qarm = QuantumAssociationRulesMining(data, 0.3, 0.5)
+
+        # QARM structure for this dataset: items_qn=1, trans_qn=2, idx_qn=3
+        # Keys: tx bits (2) + item bits (1)
+        # Target item index = 0 (item A)
+        #
+        # '010' -> tx=1, item=0  : true maximum  (~0.25004000000001)
+        # '100' -> tx=2, item=0  : true maximum  (~0.25004000000000)
+        # '000' -> tx=0, item=0  : rounding impostor (0.24996, rounds to 0.25)
+        # '001' -> tx=0, item=1  : low filler
+        # '011' -> tx=1, item=1  : low filler
+        # '101' -> tx=2, item=1  : low filler
+        # '110' -> tx=3, item=0  : low filler
+        # '111' -> tx=3, item=1  : low filler
+
+        p_max_a = 0.25004000000001
+        p_max_b = 0.25004000000000
+        p_impostor = 0.24996
+        p_low = (1.0 - p_max_a - p_max_b - p_impostor) / 5.0
+
+        crafted_dict = {
+            '000': p_impostor,   # impostor: rounds to 0.25 but is lower
+            '001': p_low,
+            '010': p_max_a,      # true maximum
+            '011': p_low,
+            '100': p_max_b,      # true maximum
+            '101': p_low,
+            '110': p_low,
+            '111': p_low,
+        }
+
+        assert sum(crafted_dict.values()) == pytest.approx(1.0), \
+            "Fixture must be normalized"
+
+        # Verify that all three (p_max_a, p_max_b, p_impostor) round to the same
+        assert round(p_max_a, 4) == round(p_max_b, 4) == round(p_impostor, 4), \
+            "Fixture must demonstrate rounding ambiguity"
+
+        def mock_iter_cir(*args, **kwargs):
+            return crafted_dict
+
+        monkeypatch.setattr(qarm, '_iter_cir', mock_iter_cir)
+
+        from pyqpanda3.core import CPUQVM, QProg
+        machine = CPUQVM()
+        qarm.machine = machine
+        prog = QProg(qarm.number_qubits)
+        qlist = prog.qubits()
+        clist = prog.cbits()
+        position = 0
+
+        result = qarm._get_result(qlist, clist, position, 1, 1, None, "", "CPU")
+
+        # Expected: both true maxima decoded
+        # key '010' -> tx=1, item=0
+        # key '100' -> tx=2, item=0
+        expected = {(1, 0), (2, 0)}
+        assert set(result) == expected, \
+            f"Expected {expected}, got {set(result)}. " \
+            f"Impostor key '000' (tx=0,item=0) must be excluded."
+
+
+# ============================================================
+# GREEN control: existing normal case still passes
+# ============================================================
+
+class TestExistingNormalCase:
+    """Verify that the existing normal-case test contract still holds."""
+
+    def test_qarm_returns_dict(self, data2):
+        """QARM run() returns a non-None dict (existing contract)."""
+        result = qarm_public_run(data2, 0.2, 0.5)
+        assert result is not None
+        assert isinstance(result, dict)


### PR DESCRIPTION
关联 Issue：#13（2026 本源杯开源创新赛道｜代码贡献）

## 一、问题 / Problem

当前 QARM 实现在合法 transaction dataset 上可能返回错误的 frequent-itemset support 和 association rules，甚至产生大于 1 的支持度。

仓库自带 `data2.txt` 包含 10 条 transaction，其中“面包”实际出现 7 次，因此：

```text
expected support(面包) = 7 / 10 = 0.7
```

修复前，QARM 的一阶搜索可能恢复出 57 个所谓 matching states：

```text
observed support(面包) = 57 / 10 = 5.7
```

该错误会沿着：

```text
_find_f1
→ F1
→ higher-order frequent itemsets
→ confidence
→ final association rules
```

继续传播。

例如：

```text
牛奶 -> 面包

QARM before:      1.00
exact classical:  0.80
```

因此这不是显示或精度问题，而是最终关联规则结果的 correctness defect。

---

## 二、原因 / Root Cause

当前 QARM 的一阶搜索对不同 target item 使用同一套、与实际 marked-state 数量 `M` 无关的 amplitude-amplification schedule。

对当前 QARM 双索引寄存器线路的概率行为验证表明，奇数 `t` 对应：

```text
t = 1 -> effective Grover k = 0
t = 3 -> effective Grover k = 1
t = 5 -> effective Grover k = 2
t = 7 -> effective Grover k = 3
t = 9 -> effective Grover k = 4
```

当 target item 较频繁时，原有较深 schedule 会发生 over-rotation，使 unmarked states 的概率反而高于 marked states。

以 `data2.txt` 的“面包”为例：

```text
N = 64
M = 7
```

`t=3` 时 marked states 构成最大概率平台；原 schedule 使用 `t=9` 时则已经发生明显 over-rotation。

此外，原 `_get_result()`：

1. 将概率四舍五入到 4 位后判断最大值；
2. 根据 probability dictionary 中 value 的位置推导 basis state。

这会带来两个额外问题：

- 接近但不相等的 probability 可能被错误合并；
- 解码隐式依赖 dictionary enumeration order，而不是实际 basis-state key。

---

## 三、修复 / Fix

本 PR 保持现有 QARM architecture，只修改一阶搜索所需的最小范围。

### 1. 3 个及以上 item：固定浅层 `t=3`

QARM 后续需要的是**完整 matching row set**，而不是只采样出一个 marked state，因此这里的目标并不是最大化单次 Grover success probability，而是保证：

```text
marked per-state probability
>
unmarked per-state probability
```

设：

```text
r = M / N
```

一次有效 Grover rotation 后：

```text
p_marked - p_unmarked = 8(1 - 2r) / N
```

因此只要：

```text
r < 1/2
```

即可形成严格 probability separation。

对当前 QARM，当 item 数量不少于 3 时：

```text
items_qubit_number >= 2
```

且：

```text
M / N <= 1 / 2^items_qubit_number <= 1/4
```

因此 `t=3` 足以稳定区分 marked / unmarked states，而不需要预先知道 `M` 或额外执行 Quantum Counting。

### 2. 直接按 probability key 解码

`_get_result()` 现在：

- 使用实际 bit-string key 解码 basis state；
- 使用 `math.isclose(..., rel_tol=1e-10)` 聚合理论相等的最大概率 states；
- 不再依赖 dictionary value position；
- 过滤 padded transaction states；
- 显式验证 target-item index。

### 3. Two-item domain 使用 exact classical fallback

当只有两个 item 时：

```text
items_qubit_number == 1
```

合法输入可能达到：

```text
M / N = 1/2
```

此时 marked 和 unmarked per-state probability 无法通过 Grover rotation 分离。

因此该完整 domain 直接从 QARM 已有 transaction matrix 精确恢复 matching rows。

这样保持 downstream contract 不变：

```text
matching rows
→ support
→ higher-order row intersection
→ confidence
```

而不引入 Quantum Counting、随机 unknown-M search 或更大的 architecture rewrite。

---

## 四、验证 / Validation

### Committed regression tests

新增：

```text
test/QARM/Test_QARM_search_correctness.py
```

覆盖：

- `data2.txt` 的“面包” row recovery / support；
- `牛奶 -> 面包` confidence；
- dense high-frequency case；
- two-item `M/N = 1/2` boundary；
- probability-dictionary ordering；
- 4-decimal rounding impostor；
- padded states；
- existing valid behavior。

执行结果：

```bash
python -m pytest -o addopts="" \
  test/QARM/Test_QARM_search_correctness.py -q
# 11 passed

python -m pytest -o addopts="" test/QARM -q
# 12 passed

python -m pytest -o addopts="" \
  test --ignore=test/QARM/Test_QARM_search_correctness.py -q
# 18 passed

python -m pytest -o addopts="" test -q
# 29 passed
```

Focused regression 连续执行两次均为 `11 passed`。

### Supplementary systematic validation

提交前另使用未随 PR 提交的 deterministic small-dataset validation，对修复进行了补充核验：

```text
35 datasets
116 F1 row comparisons
188 frequent-itemset comparisons
110 pair-rule comparisons
0 mismatches
0 support invariant violations
```

并覆盖 support / confidence threshold 的 below / equal / above boundary。

上述 systematic sweep 属于补充验证；PR 中可直接复现的权威 regression 仍为本次提交的测试文件。

---

## 五、资源影响 / Resource Impact

修复后的 3+ item quantum path 固定使用：

```text
t = 3
```

而原实现代表性 case 使用 `t = 5` 或 `t = 9`。

在 9 个 correctness-aware benchmark case 中：

```text
fixed QARM: 9/9 correct
old QARM:   6/9 correct
```

在 old / fixed 都正确的 6 个 case 中，修复版本的 median runtime 均较低。

这里的主要目标仍然是 correctness；runtime 变化仅作为 resource impact 记录，不作为独立性能优化 claim。

---

## 六、兼容性与行为变化 / Compatibility

- Public constructor / `run()` API：不变；
- Return dictionary structure：不变；
- 新增第三方依赖：无；
- 3+ item path：继续使用 QARM quantum search；
- two-item path：改为 exact classical singleton-row recovery。

一个有意的细微行为差异是：

> two-item F1 path 不再构建 quantum search circuit，因此该路径下 `show` / `file_name` 对 F1 circuit visualization 不生效。

CPUQVM 路径已实际验证。

QCloud `full_amplitude` 路径从源码和 probability-dictionary contract 上与本修复兼容，但本 PR 未使用实时 QCloud credentials 执行验证。

本修复依赖当前 QARM 使用的**完整理想 probability distribution** 来恢复最大概率平台，不声称等价适用于 finite-shot sampling。

---

## 七、已知限制 / Known Limitations

### 1. `_get_all_conf()` 的规则枚举范围

当前 `_get_all_conf()` 主要生成 `(k-1) -> 1` 类型规则，并不完整枚举所有 multi-item consequent。

这是与本次 F1 quantum-search correctness 独立的既有问题，本 PR 不扩大范围处理。

### 2. 本 PR 修复的是当前仓库实现

本 PR 的目标是：

> fix the current `pyqpanda-algorithm` QARM implementation

不声称修改或修复原始 QARM 论文中的完整算法架构。

---

## 八、Related Work / Non-overlap

- #36 修正 generic Grover 在已知 marked-state 数量 `M` 时的最优 iteration selection。  
  本 PR 中 QARM 的 `M` 未知，而且目标是从完整 probability distribution 恢复完整 matching row set，因此问题和 repair objective 不同。

- #47 新增 Quantum Counting，通过 phase estimation 估计 `M`。  
  本 PR 利用当前 QARM domain 的 `M/N` 上界，在 3+ item 情况下无需先估计 `M`。

因此两者与本 PR 技术相关，但不存在直接实现重复。

---

## English Summary

This PR fixes a correctness defect in the current QARM implementation that can produce impossible support values and incorrect association rules on valid transaction datasets.

- On the bundled `data2.txt`, bread appears in 7 of 10 transactions, so its exact support is `0.7`; before the fix QARM can recover 57 states and report `5.7`.
- The incorrect F1 result propagates into confidence values and final rules; for example, `milk -> bread` is reported as `1.00` instead of the exact `0.80`.
- The main cause is an `M`-independent amplification schedule that can over-rotate dense marked sets. For the current two-index-register QARM circuit, odd `t` follows `k=(t-1)/2` effective Grover rotations.
- For three or more items, `M/N <= 1/4`, so `t=3` provides marked/unmarked probability separation without first estimating `M`. The two-item domain uses exact classical row recovery because `M/N` can reach `1/2`.
- Probability results are now decoded from their actual bit-string keys, using a tight floating-point tolerance and explicit transaction/item filtering instead of rounded values and dictionary positions.
- The committed focused regression suite has 11 cases; the full explicit test tree is `29 passed`. A separate deterministic 35-dataset validation produced zero F1, frequent-itemset or pair-rule mismatches against an exact classical reference.
- No public API or output-shape change is introduced, and no new third-party dependency is required.
- The repair assumes the current ideal full-probability-distribution execution model. QCloud `full_amplitude` compatibility was reviewed from the source path but was not live-tested with credentials. Higher-order consequent enumeration in `_get_all_conf()` remains a separate pre-existing limitation.
