### PR TITLE
【代码贡献】优化 QSEncode Walsh 变换与 Top-K 筛选性能

### DIFF
--- a/pyqpanda-algorithm/pyqpanda_alg/QSEncode/QSEncode.py
+++ b/pyqpanda-algorithm/pyqpanda_alg/QSEncode/QSEncode.py
@@ -14,9 +14,54 @@ import matplotlib.pyplot as plt
 import numpy as np
 from pyqpanda3.core import CPUQVM, QCircuit, QProg, Encode, H
 from scipy.fft import fft
-from sympy import fwht
 
 from .. plugin import *
+
+
+def _fast_walsh_hadamard_transform(values):
+    """Return the unnormalized Walsh-Hadamard transform of a 1-D array.
+
+    The input is zero-padded to the next power-of-two length, matching the
+    behavior of :func:`sympy.fwht`.  The butterfly is evaluated with NumPy
+    ufuncs, so numeric values stay in a native numeric dtype instead of being
+    converted to symbolic Python objects.
+
+    The input is never modified.  Runtime is ``O(N log N)`` and auxiliary
+    memory is ``O(N)``.
+    """
+    array = np.asarray(values)
+    if array.ndim != 1:
+        raise ValueError('values must be a 1D array')
+    if not np.issubdtype(array.dtype, np.number):
+        raise TypeError('values must contain numeric data')
+
+    size = array.size
+    dtype = np.result_type(array.dtype, np.float64)
+    if size == 0:
+        return np.empty(0, dtype=dtype)
+
+    padded_size = 1 << (size - 1).bit_length()
+    output = np.zeros(padded_size, dtype=dtype)
+    output[:size] = array
+    if padded_size == 1:
+        return output
+
+    # One reusable half-size buffer avoids allocating a Python/SymPy object
+    # for every coefficient and avoids a fresh temporary at every stage.
+    scratch = np.empty(padded_size // 2, dtype=dtype)
+    step = 1
+    while step < padded_size:
+        blocks = output.reshape(-1, 2 * step)
+        left = blocks[:, :step]
+        right = blocks[:, step:]
+        saved_left = scratch.reshape(-1, step)
+        np.copyto(saved_left, left)
+        np.add(saved_left, right, out=left)
+        np.subtract(saved_left, right, out=right)
+        step *= 2
+
+    return output
+
 
 class QSpare_Code:
     
@@ -146,15 +191,50 @@ class QSpare_Code:
         -------
         np.ndarray
             A new array with only top-n magnitudes retained, rest set to zero.
+
+        Notes
+        -----
+        Selection uses ``numpy.argpartition`` and therefore takes average
+        ``O(N)`` time.  If equal magnitudes cross the selection boundary, the
+        larger original indices are retained to make the result deterministic.
         """
         
         if type(n) != int or n <= 0:
             raise ValueError('n must > 0 and with class int')
+        arr = np.asarray(arr)
+        if arr.ndim != 1:
+            raise ValueError('arr must be a 1D array')
+        if arr.size == 0:
+            return arr.copy()
+
         magnitudes = np.abs(arr)
-        top_n_indices = np.argsort(magnitudes)[-n:]
+        if not np.all(np.isfinite(magnitudes)):
+            raise ValueError('arr must contain only finite values')
+        if n >= arr.size:
+            return arr.copy()
+
+        # argpartition finds the top-n boundary in average O(N), whereas a
+        # complete argsort performs O(N log N) work.  Values tied at the
+        # boundary are resolved by index so results are deterministic.
+        partition_at = arr.size - n
+        partitioned = np.argpartition(magnitudes, partition_at)
+        threshold = magnitudes[partitioned[partition_at]]
+        top_n_indices = partitioned[partition_at:]
+
+        # The partition result is already complete for the overwhelmingly
+        # common unique-boundary case.  Only scan and rebuild the selection
+        # when equal magnitudes straddle the top-n boundary.
+        selected_ties = np.count_nonzero(magnitudes[top_n_indices] == threshold)
+        all_ties = np.count_nonzero(magnitudes == threshold)
+        if selected_ties != all_ties:
+            top_n_indices = np.flatnonzero(magnitudes > threshold)
+            slots_left = n - top_n_indices.size
+            tied_indices = np.flatnonzero(magnitudes == threshold)
+            top_n_indices = np.concatenate((top_n_indices, tied_indices[-slots_left:]))
+
         result = np.zeros_like(arr, dtype=arr.dtype)
         result[top_n_indices] = arr[top_n_indices]
-        return np.array(result)
+        return result
 
     def Transform(self, amp):
         """
@@ -169,9 +249,15 @@ class QSpare_Code:
         -------
         np.ndarray
             Transformed amplitude vector in the selected basis.
+
+        Notes
+        -----
+        Walsh mode uses a native NumPy fast Walsh-Hadamard butterfly with
+        ``O(N log N)`` time and ``O(N)`` memory.
         """
         if self.mode == 'walsh':
-            transform = np.array(fwht(amp)) / np.sqrt(2 ** self.qubits_num)
+            transform = _fast_walsh_hadamard_transform(amp)
+            transform /= np.sqrt(2 ** self.qubits_num)
         elif self.mode == 'fourier':
             transform = fft(amp)
         else:

--- a/test/QAlgBase/Test_QSEncode_numeric_pipeline.py
+++ b/test/QAlgBase/Test_QSEncode_numeric_pipeline.py
@@ -1,0 +1,165 @@
+import numpy as np
+import pytest
+
+from pyqpanda_alg.QSEncode.QSEncode import (
+    QSpare_Code,
+    _fast_walsh_hadamard_transform,
+)
+
+
+def _hadamard_matrix(size):
+    """Build a small independent Sylvester Hadamard matrix."""
+    matrix = np.array([[1.0]])
+    while matrix.shape[0] < size:
+        matrix = np.block([[matrix, matrix], [matrix, -matrix]])
+    return matrix
+
+
+def _dense_fwht(values):
+    """Reference transform using an explicit matrix, not a butterfly."""
+    values = np.asarray(values)
+    if values.size == 0:
+        return np.empty(0, dtype=np.result_type(values.dtype, np.float64))
+    padded_size = 1 << (values.size - 1).bit_length()
+    padded = np.zeros(padded_size, dtype=np.result_type(values.dtype, np.float64))
+    padded[:values.size] = values
+    return _hadamard_matrix(padded_size) @ padded
+
+
+def _dense_sparse_walsh_probabilities(probabilities, cut):
+    """Independent end-to-end oracle for the Walsh sparse encoder."""
+    probabilities = np.asarray(probabilities, dtype=float)
+    amplitudes = np.sqrt(probabilities / probabilities.sum())
+    size = amplitudes.size
+    hadamard = _hadamard_matrix(size) / np.sqrt(size)
+    coefficients = hadamard @ amplitudes
+
+    order = np.argsort(np.abs(coefficients), kind='stable')
+    sparse = np.zeros_like(coefficients)
+    sparse[order[-cut:]] = coefficients[order[-cut:]]
+    sparse /= np.linalg.norm(sparse)
+    return np.abs(hadamard @ sparse) ** 2
+
+
+@pytest.mark.parametrize(
+    'values',
+    [
+        np.array([], dtype=float),
+        np.array([3.25]),
+        np.array([1.0, -2.0, 4.0]),
+        np.array([1.0, 2.0, 3.0, 4.0]),
+        np.array([1.0 + 2.0j, -3.0j, 0.5 - 0.25j]),
+    ],
+)
+def test_fast_walsh_transform_matches_dense_oracle(values):
+    actual = _fast_walsh_hadamard_transform(values)
+    expected = _dense_fwht(values)
+
+    assert actual.dtype != object
+    np.testing.assert_allclose(actual, expected, rtol=0.0, atol=1e-12)
+
+
+def test_fast_walsh_transform_matches_dense_oracle_for_lengths_1_to_64():
+    rng = np.random.default_rng(20260901)
+
+    for size in range(1, 65):
+        values = rng.normal(size=size)
+        if size % 2 == 0:
+            values = values + 1j * rng.normal(size=size)
+        actual = _fast_walsh_hadamard_transform(values)
+        expected = _dense_fwht(values)
+        np.testing.assert_allclose(actual, expected, rtol=1e-13, atol=1e-12)
+
+
+@pytest.mark.parametrize('qubits', range(13))
+def test_normalized_walsh_transform_preserves_norm_and_is_self_inverse(qubits):
+    size = 1 << qubits
+    values = np.random.default_rng(qubits).normal(size=size)
+    transformed = _fast_walsh_hadamard_transform(values) / np.sqrt(size)
+    restored = _fast_walsh_hadamard_transform(transformed) / np.sqrt(size)
+
+    np.testing.assert_allclose(np.linalg.norm(transformed), np.linalg.norm(values), rtol=1e-13)
+    np.testing.assert_allclose(restored, values, rtol=1e-13, atol=1e-13)
+
+
+def test_fast_walsh_transform_does_not_modify_input_and_promotes_numeric_dtype():
+    values = np.array([1, 2, 3], dtype=np.int16)
+    original = values.copy()
+
+    result = _fast_walsh_hadamard_transform(values)
+
+    np.testing.assert_array_equal(values, original)
+    assert result.dtype == np.float64
+
+
+def test_fast_walsh_transform_rejects_non_numeric_or_non_vector_input():
+    with pytest.raises(ValueError, match='1D'):
+        _fast_walsh_hadamard_transform(np.ones((2, 2)))
+    with pytest.raises(TypeError, match='numeric'):
+        _fast_walsh_hadamard_transform(['a', 'b'])
+
+
+@pytest.mark.parametrize(
+    ('size', 'cut'),
+    [(8, 1), (8, 7), (257, 17), (4096, 63)],
+)
+def test_linear_top_k_matches_full_stable_sort_for_unique_magnitudes(size, cut):
+    rng = np.random.default_rng(size + cut)
+    phases = np.exp(2j * np.pi * rng.random(size))
+    values = np.arange(1, size + 1, dtype=float) * phases
+    encoder = QSpare_Code([0.5, 0.5])
+
+    actual = encoder.select_top_n_complex_numbers(values, cut)
+    expected = np.zeros_like(values)
+    expected_indices = np.argsort(np.abs(values), kind='stable')[-cut:]
+    expected[expected_indices] = values[expected_indices]
+
+    np.testing.assert_array_equal(actual, expected)
+
+
+def test_linear_top_k_has_deterministic_boundary_ties():
+    values = np.array([-3.0, 3.0, 2.0, -2.0, 1.0])
+    encoder = QSpare_Code([0.5, 0.5])
+
+    actual = encoder.select_top_n_complex_numbers(values, 3)
+
+    np.testing.assert_array_equal(actual, [-3.0, 3.0, 0.0, -2.0, 0.0])
+
+
+def test_linear_top_k_keeps_input_unchanged_and_fast_paths_full_selection():
+    values = np.array([1.0 + 2.0j, -4.0j, 3.0])
+    original = values.copy()
+    encoder = QSpare_Code([0.5, 0.5])
+
+    result = encoder.select_top_n_complex_numbers(values, values.size)
+
+    np.testing.assert_array_equal(values, original)
+    np.testing.assert_array_equal(result, original)
+    assert result is not values
+
+
+def test_linear_top_k_rejects_invalid_shape_and_non_finite_values():
+    encoder = QSpare_Code([0.5, 0.5])
+    with pytest.raises(ValueError, match='1D'):
+        encoder.select_top_n_complex_numbers(np.ones((2, 2)), 1)
+    with pytest.raises(ValueError, match='finite'):
+        encoder.select_top_n_complex_numbers(np.array([1.0, np.nan]), 1)
+    with pytest.raises(ValueError, match='finite'):
+        encoder.select_top_n_complex_numbers(np.array([1.0, np.inf]), 2)
+
+
+@pytest.mark.parametrize(
+    ('probabilities', 'cut'),
+    [
+        ([0.50, 0.30, 0.15, 0.05], 2),
+        ([0.31, 0.19, 0.16, 0.12, 0.09, 0.06, 0.04, 0.03], 3),
+    ],
+)
+def test_walsh_quantum_result_matches_independent_dense_pipeline(probabilities, cut):
+    encoder = QSpare_Code(list(map(float, probabilities)), mode='walsh', cut_length=cut)
+
+    actual = encoder.Quantum_Res()
+    expected = _dense_sparse_walsh_probabilities(probabilities, cut)
+
+    np.testing.assert_allclose(actual, expected, rtol=1e-9, atol=1e-9)
+    np.testing.assert_allclose(np.sum(actual), 1.0, rtol=0.0, atol=1e-12)


### PR DESCRIPTION
关联 Issue：#13（2026 本源杯开源创新赛道｜代码贡献）
参赛队伍：Basia

## 简介

`QSpare_Code` 在 Walsh 稀疏编码预处理中存在两个性能热点：

1. `sympy.fwht` 会将纯数值输入带入 SymPy 符号对象流水线，带来较高的 Python 对象与内存分配开销。
2. 原 Top-K 筛选使用完整 `numpy.argsort`，即使只保留少量系数，仍需对所有 N 个幅值排序。

本 PR 将两条热路径改为原生 NumPy 数值实现，并增加独立正确性测试和可复现基准。

## 主要修改

- 新增 `_fast_walsh_hadamard_transform`：
  - 使用 NumPy ufunc 和可复用 scratch 缓冲区执行蝶形计算；
  - 保持非 2 的幂输入补零语义；
  - 保持原生数值 dtype，不产生 `object` 数组；
  - 时间复杂度 `O(N log N)`，辅助空间 `O(N)`。
- 将 Top-K 选择由完整 `argsort` 替换为 `argpartition`，平均时间复杂度由 `O(N log N)` 降为 `O(N)`。
- 等幅值跨越 Top-K 截断边界时，明确按较大原索引优先保留，保证结果可重现。
- 增加一维/数值/有限值校验，以及空输入、`n >= N` 快路径。
- 新增 30 个参数化用例和一个旧/新实现性能基准脚本。

> 注：原 `sympy.fwht` 本身也是 `O(N log N)` 快速变换。FWHT 加速主要来自减少符号对象、Python 常数和临时分配，而不是改变渐进时间复杂度。

## 正确性与测试

- 使用独立 Sylvester Hadamard 稠密矩阵对拍 FWHT；
- 覆盖空/单元素/非 2 的幂/实数/复数输入和长度 1–64；
- 覆盖 0–12 比特归一化变换的范数保持与自反演；
- 覆盖 Top-K 复数、并列边界、快路径与非法输入；
- 覆盖 2 组 `Quantum_Res()` 端到端概率分布对拍。

本地定向测试（新增 30 例 + 原有 1 例）：

```text
31 passed in 0.87s
```

## 性能数据

环境：Python 3.11.6，NumPy 2.4.6，SymPy 1.14.0，PyQPanda3 0.3.2。每组重复 3 次取中位数，最小采样时间 0.02 s。结果为单机参考，不作为跨平台保证。

| FWHT N | SymPy 基线 | NumPy 优化 |   加速比 |
| -----: | ---------: | ---------: | -------: |
|    256 |  16.020 ms |    55.6 µs |   287.9× |
|  1,024 |  74.826 ms |    87.4 µs |   856.3× |
|  4,096 | 427.510 ms |   193.3 µs | 2,211.3× |
| 16,384 |    1.915 s |   627.3 µs | 3,052.7× |

N=4,096 时，`tracemalloc` 跟踪的 Python 峰值分配由 0.855 MiB 降为 0.080 MiB，约降低 10.7 倍。

|   Top-K N |      K | 完整 `argsort` | `argpartition` | 加速比 |
| --------: | -----: | -------------: | -------------: | -----: |
|    16,384 |    163 |       377.6 µs |       135.9 µs |   2.8× |
|   262,144 |  2,621 |       9.728 ms |       2.362 ms |   4.1× |
| 1,048,576 | 10,485 |      68.358 ms |      15.736 ms |   4.3× |

|     N | 电路构建加速 | `Quantum_Res` 加速 | 最大误差 |
| ----: | -----------: | -----------------: | -------: |
|   256 |         9.9× |               4.9× |  0.0e+00 |
| 1,024 |        11.3× |               6.0× |  0.0e+00 |

## 兼容性说明

- `QSpare_Code` 公共 API 和方法签名不变。
- Fourier 模式未修改。
- Walsh 对常规一维有限数值输入保持算法语义，只可能存在浮点舍入差异。
- 输入更严格：多维数组、`NaN` 和 `Inf` 现在会抛出明确异常。
- 并列幅值跨越 Top-K 边界时，新实现使用明确的较大索引优先策略；该边界下的系数选择可能与旧的默认非稳定排序不同。
- 本 PR 只从 QSEncode Walsh 热路径移除 `sympy.fwht`，不移除整个项目的 SymPy 依赖。

## 复现

```bash
PYTHONPATH=pyqpanda-algorithm python -m pytest \
  -c test/pytest.ini -o addopts='' -p no:cacheprovider \
  test/QAlgBase/Test_QSEncode_numeric_pipeline.py \
  test/QAlgBase/Test_class_basic_sparecode_QSpare_Code.py -q

python benchmarks/benchmark_qsencode.py \
  --repeats 3 \
  --minimum-sample-time 0.02
```

## 变更文件

- `pyqpanda-algorithm/pyqpanda_alg/QSEncode/QSEncode.py`
- `test/QAlgBase/Test_QSEncode_numeric_pipeline.py`